### PR TITLE
Fixed rails logger indentation

### DIFF
--- a/lib/rom/sql/support/rails_log_subscriber.rb
+++ b/lib/rom/sql/support/rails_log_subscriber.rb
@@ -19,7 +19,7 @@ module ROM
           name = color(name, :magenta, true)
         end
 
-        debug "   #{name}  #{sql}  #{binds}"
+        debug "  #{name}  #{sql}  #{binds}"
       end
 
       def odd?


### PR DESCRIPTION
Now ROM logs are indented in the same way as ActiveRecord