### PR TITLE
Don't unnecessarily load header

### DIFF
--- a/lib/rom/sql/relation_inclusion.rb
+++ b/lib/rom/sql/relation_inclusion.rb
@@ -21,7 +21,6 @@ module ROM
       def initialize(*args)
         super
         @model = self.class.model
-        @header = dataset.header
       end
 
       # Join configured association.


### PR DESCRIPTION
Removes unused code and improves the situation described in rom-rb/rom#109.