### PR TITLE
Make it work with subclass-based setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rom', '~> 0.5.0', github: 'rom-rb/rom', branch: 'master'
+  gem 'rom', '~> 0.5.0', github: 'rom-rb/rom', branch: 'setup-dsl-refactor'
+  gem 'minitest'
   gem 'virtus'
   gem 'activesupport'
   gem 'rspec', '~> 3.1'
@@ -13,6 +14,7 @@ group :test do
 end
 
 group :tools do
+  gem 'byebug'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rom', '~> 0.5.0', github: 'rom-rb/rom', branch: 'setup-dsl-refactor'
+  gem 'rom', '~> 0.5.0', github: 'rom-rb/rom', branch: 'master'
   gem 'minitest'
   gem 'virtus'
   gem 'activesupport'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :test do
 end
 
 group :tools do
-  gem 'byebug'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-rubocop'

--- a/lib/rom/sql.rb
+++ b/lib/rom/sql.rb
@@ -9,7 +9,7 @@ end
 
 require "rom/sql/version"
 require "rom/sql/header"
-require "rom/sql/relation_inclusion"
+require "rom/sql/relation"
 require "rom/sql/repository"
 
 require "rom/sql/support/sequel_dataset_ext"

--- a/lib/rom/sql/commands.rb
+++ b/lib/rom/sql/commands.rb
@@ -15,7 +15,8 @@ module ROM
         end
       end
 
-      class Create < ROM::Commands::Create
+      module Create
+        include ROM::Commands::Create
         include TupleCount
 
         def execute(tuples)
@@ -31,7 +32,8 @@ module ROM
         end
       end
 
-      class Update < ROM::Commands::Update
+      module Update
+        include ROM::Commands::Update
         include TupleCount
 
         def execute(tuple)
@@ -45,7 +47,8 @@ module ROM
         end
       end
 
-      class Delete < ROM::Commands::Delete
+      module Delete
+        include ROM::Commands::Delete
         include TupleCount
 
         def execute

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -2,26 +2,30 @@ module ROM
   module SQL
     # Sequel-specific relation extensions
     #
-    module RelationInclusion
+    module Relation
       def self.included(klass)
         klass.class_eval do
+          extend ClassMethods
           extend AssociationDSL
 
           undef_method :select
+        end
+      end
 
-          class << self
-            attr_accessor :model
-          end
+      module ClassMethods
+        attr_reader :model
 
-          self.model = Class.new(Sequel::Model)
+        def inherited(klass)
+          super
+          klass.instance_variable_set('@model', Class.new(Sequel::Model))
         end
       end
 
       def exposed_relations
         super + (dataset.public_methods & public_methods) -
           Object.public_instance_methods -
-          Relation.public_instance_methods -
-          RelationInclusion.public_instance_methods
+          ROM::Relation.public_instance_methods -
+          SQL::Relation.public_instance_methods
       end
 
       def model

--- a/lib/rom/sql/relation_inclusion.rb
+++ b/lib/rom/sql/relation_inclusion.rb
@@ -4,17 +4,24 @@ module ROM
     #
     module RelationInclusion
       def self.included(klass)
-        klass.extend(AssociationDSL)
-
-        klass.send(:undef_method, :select)
-
         klass.class_eval do
+          extend AssociationDSL
+
+          undef_method :select
+
           class << self
             attr_accessor :model
           end
 
           self.model = Class.new(Sequel::Model)
         end
+      end
+
+      def exposed_relations
+        super + (dataset.public_methods & public_methods) -
+          Object.public_instance_methods -
+          Relation.public_instance_methods -
+          RelationInclusion.public_instance_methods
       end
 
       def model

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sequel", "~> 4.17"
+  spec.add_runtime_dependency "sequel", "~> 4.18"
   spec.add_runtime_dependency "equalizer", "~> 0.0", ">= 0.0.9"
   spec.add_runtime_dependency "rom", "~> 0.5", ">= 0.5.0"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,28 @@ end
 
 require 'rom-sql'
 require 'logger'
+require 'byebug'
 
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 
 root = Pathname(__FILE__).dirname
 
 Dir[root.join('shared/*.rb').to_s].each { |f| require f }
+
+RSpec.configure do |config|
+  config.before do
+    @constants = Object.constants
+  end
+
+  config.after do
+    [ROM::Relation, ROM::Mapper, ROM::Command].each { |klass| clear_descendants(klass) }
+
+    added_constants = Object.constants - @constants
+    added_constants.each { |name| Object.send(:remove_const, name) }
+  end
+
+  def clear_descendants(klass)
+    klass.descendants.each { |d| clear_descendants(d) }
+    klass.instance_variable_set('@descendants', [])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ if RUBY_ENGINE == 'rbx'
 end
 
 require 'rom-sql'
+require 'pg'
 require 'logger'
 
 begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,14 +8,9 @@ if RUBY_ENGINE == 'rbx'
   CodeClimate::TestReporter.start
 end
 
-require 'rom-sql'
 require 'pg'
+require 'rom-sql'
 require 'logger'
-
-begin
-  require 'byebug'
-rescue LoadError
-end
 
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,9 @@ if RUBY_ENGINE == 'rbx'
   CodeClimate::TestReporter.start
 end
 
-require 'pg'
 require 'rom-sql'
+# FIXME: why do we need to require it manually??
+require 'sequel/adapters/postgres'
 require 'logger'
 
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,11 @@ end
 
 require 'rom-sql'
 require 'logger'
-require 'byebug'
+
+begin
+  require 'byebug'
+rescue LoadError
+end
 
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 

--- a/spec/unit/one_to_many_spec.rb
+++ b/spec/unit/one_to_many_spec.rb
@@ -4,8 +4,6 @@ describe 'Defining one-to-many association' do
   include_context 'users and tasks'
 
   it 'extends relation with association methods' do
-    setup.relation(:tasks)
-
     setup.relation(:users) do
       one_to_many :tasks, key: :user_id
 


### PR DESCRIPTION
This changes `RelationInclusion` to a `Relation` subclass which makes it work with new way of setting up ROM

refs rom-rb/rom#133