### PR TITLE
Dirty attributes update

### DIFF
--- a/lib/rom/sql/commands.rb
+++ b/lib/rom/sql/commands.rb
@@ -7,12 +7,6 @@ module ROM
         Sequel::UniqueConstraintViolation,
         Sequel::NotNullConstraintViolation
       ].freeze
-
-      module TupleCount
-        def tuple_count
-          target.count
-        end
-      end
     end
   end
 end

--- a/lib/rom/sql/commands/create.rb
+++ b/lib/rom/sql/commands/create.rb
@@ -27,7 +27,7 @@ module ROM
 
         def insert(tuples)
           pks = tuples.map { |tuple| relation.insert(tuple) }
-          relation.where(relation.model.primary_key => pks)
+          relation.where(relation.primary_key => pks)
         end
       end
     end

--- a/lib/rom/sql/commands/create.rb
+++ b/lib/rom/sql/commands/create.rb
@@ -4,8 +4,6 @@ module ROM
   module SQL
     module Commands
       class Create < ROM::Commands::Create
-        include TupleCount
-
         def self.build(relation, options = {})
           case relation.db.database_type
           when :postgres

--- a/lib/rom/sql/commands/delete.rb
+++ b/lib/rom/sql/commands/delete.rb
@@ -4,8 +4,6 @@ module ROM
   module SQL
     module Commands
       class Delete < ROM::Commands::Delete
-        include TupleCount
-
         def execute
           deleted = target.to_a
           target.delete

--- a/lib/rom/sql/commands/update.rb
+++ b/lib/rom/sql/commands/update.rb
@@ -4,8 +4,6 @@ module ROM
   module SQL
     module Commands
       class Update < ROM::Commands::Update
-        include TupleCount
-
         option :original, type: Hash, reader: true
 
         alias_method :to, :call

--- a/lib/rom/sql/commands/update.rb
+++ b/lib/rom/sql/commands/update.rb
@@ -6,15 +6,39 @@ module ROM
       class Update < ROM::Commands::Update
         include TupleCount
 
+        option :original, type: Hash, reader: true
+
+        alias_method :to, :call
+
         def execute(tuple)
           attributes = input[tuple]
           validator.call(attributes)
 
-          pks = relation.map { |t| t[relation.model.primary_key] }
+          changed = diff(attributes.to_h)
 
-          relation.update(attributes.to_h)
-          relation.unfiltered.where(relation.model.primary_key => pks)
+          if changed.any?
+            pks = relation.map { |t| t[relation.model.primary_key] }
+            relation.update(changed)
+            relation.unfiltered.where(relation.model.primary_key => pks)
+          else
+            []
+          end
         end
+
+        def change(original)
+          self.class.new(relation, options.merge(original: original))
+        end
+
+        private
+
+        def diff(tuple)
+          if original
+            Hash[tuple.to_a - (tuple.to_a & original.to_a)]
+          else
+            tuple
+          end
+        end
+
       end
     end
   end

--- a/lib/rom/sql/commands/update.rb
+++ b/lib/rom/sql/commands/update.rb
@@ -34,9 +34,9 @@ module ROM
           self.class.new(relation, options.merge(original: original))
         end
 
-        def update
+        def update(tuple)
           pks = relation.map { |t| t[relation.model.primary_key] }
-          relation.update(changed)
+          relation.update(tuple)
           relation.unfiltered.where(relation.model.primary_key => pks).to_a
         end
 

--- a/lib/rom/sql/commands_ext/postgres.rb
+++ b/lib/rom/sql/commands_ext/postgres.rb
@@ -7,19 +7,15 @@ module ROM
       module Postgres
         class Create < Commands::Create
           def insert(tuples)
-            pk = Array(relation.model.primary_key)
-            keys = nil
-
             tuples.map do |tuple|
-              keys ||= pk + tuple.keys
-              relation.dataset.returning(*keys).insert(tuple)
+              relation.dataset.returning(*relation.columns).insert(tuple)
             end.flatten
           end
         end
 
         class Update < Commands::Update
           def update(tuple)
-            relation.dataset.returning(*relation.model.columns).update(tuple)
+            relation.dataset.returning(*relation.columns).update(tuple)
           end
         end
       end

--- a/lib/rom/sql/commands_ext/postgres.rb
+++ b/lib/rom/sql/commands_ext/postgres.rb
@@ -1,4 +1,5 @@
 require 'rom/sql/commands/create'
+require 'rom/sql/commands/update'
 
 module ROM
   module SQL
@@ -13,6 +14,12 @@ module ROM
               keys ||= pk + tuple.keys
               relation.dataset.returning(*keys).insert(tuple)
             end.flatten
+          end
+        end
+
+        class Update < Commands::Update
+          def update(tuple)
+            relation.dataset.returning(*relation.model.columns).update(tuple)
           end
         end
       end

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -27,6 +27,14 @@ describe 'Commands / Update' do
     relation.insert(name: 'Piotr')
   end
 
+  it 'updates everything when there is no original tuple' do
+    result = users.try do |c|
+      c.update(:by_id, piotr[:id]).set(peter)
+    end
+
+    expect(result.value.to_a).to match_array([{ id: 1, name: 'Peter' }])
+  end
+
   it 'updates when attributes changed' do
     result = users.try do |c|
       c.update(:by_id, piotr[:id]).change(piotr).to(peter)

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -1,26 +1,50 @@
 require 'spec_helper'
 
 describe 'Commands / Update' do
-  include_context 'users and tasks'
+  include_context 'database setup'
 
   subject(:users) { rom.commands.users }
 
-  it 'works' do
+  let(:relation) { rom.relations.users }
+  let(:piotr) { relation.by_name('Piotr').first }
+  let(:peter) { { name: 'Peter' } }
+
+  before do
     setup.relation(:users) do
+      def by_id(id)
+        where(id: id).limit(1)
+      end
+
       def by_name(name)
         where(name: name)
       end
     end
 
     setup.commands(:users) do
-      define(:update) do
-        input Hash
-        validator proc {}
-      end
+      define(:update)
     end
 
-    result = users.try { update(:by_name, 'Piotr').set(name: 'Peter') }
+    relation.insert(name: 'Piotr')
+  end
+
+  it 'updates when attributes changed' do
+    result = users.try do |c|
+      c.update(:by_id, piotr[:id]).change(piotr).to(peter)
+    end
 
     expect(result.value.to_a).to match_array([{ id: 1, name: 'Peter' }])
+  end
+
+  it 'does not update when attributes did not change' do
+    piotr_rel = double('piotr_rel').as_null_object
+
+    expect(relation).to receive(:by_id).with(piotr[:id]).and_return(piotr_rel)
+    expect(piotr_rel).not_to receive(:update)
+
+    result = users.try do |c|
+      c.update(:by_id, piotr[:id]).change(piotr).to(name: piotr[:name])
+    end
+
+    expect(result.value.to_a).to be_empty
   end
 end

--- a/spec/unit/commands_spec.rb
+++ b/spec/unit/commands_spec.rb
@@ -1,37 +1,61 @@
 require 'spec_helper'
 
 describe ROM::SQL::Commands do
-  include_context 'users and tasks'
+  include_context 'database setup'
 
   subject(:users) { rom.commands.users }
 
   before do
-    setup.relation(:users)
+    setup.relation(:users) do
+      def by_id(id)
+        where(id: id)
+      end
+    end
 
     setup.commands(:users) do
       define(:create) do
+        result :one
+      end
+
+      define(:update) do
         result :one
       end
     end
   end
 
   context 'postgres' do
-    it 'create instance of PostgreSQL create command' do
+    it 'creates instance of PostgreSQL create command' do
       expect(ROM::SQL::Commands::Postgres::Create)
         .to receive(:new).and_call_original
 
       users.try { create(id: 1, name: 'Foo') }
     end
+
+    it 'creates instance of PostgreSQL update command' do
+      expect(ROM::SQL::Commands::Postgres::Update)
+        .to receive(:new).and_call_original.twice
+
+      users.try { update(:by_id, 1).set(name: 'Foo') }
+    end
   end
 
   context 'others' do
-    it 'create instance of default create command' do
+    it 'creates instance of default create command' do
       type = double(database_type: :foo)
       allow_any_instance_of(ROM::Relation).to receive(:db).and_return(type)
 
       expect(ROM::SQL::Commands::Create).to receive(:new).and_call_original
 
       users.try { create(id: 1, name: 'Foo') }
+    end
+
+    it 'creates instance of default update command' do
+      type = double(database_type: :foo)
+      allow_any_instance_of(ROM::Relation).to receive(:db).and_return(type)
+
+      expect(ROM::SQL::Commands::Update).to receive(:new).and_call_original.twice
+
+      users.try { update(:by_id, 1).set(name: 'Foo') }
     end
   end
 end


### PR DESCRIPTION
This adds a way to pass in an original tuple to update command and it will skip the update if nothing was changed:

``` ruby
users.try { update(:by_id, 1).change(name: 'Jane').to(name: 'Jane Doe') }
```

As a bonus it adds pg-specific update which uses `returning` :)