### PR TITLE
Basic transaction interface for commands

### DIFF
--- a/lib/rom/sql/commands/create.rb
+++ b/lib/rom/sql/commands/create.rb
@@ -1,9 +1,12 @@
 require 'rom/sql/commands'
+require 'rom/sql/commands/transaction'
 
 module ROM
   module SQL
     module Commands
       class Create < ROM::Commands::Create
+        include Transaction
+
         def execute(tuples)
           insert_tuples = Array([tuples]).flatten.map do |tuple|
             attributes = input[tuple]

--- a/lib/rom/sql/commands/delete.rb
+++ b/lib/rom/sql/commands/delete.rb
@@ -1,9 +1,12 @@
 require 'rom/sql/commands'
+require 'rom/sql/commands/transaction'
 
 module ROM
   module SQL
     module Commands
       class Delete < ROM::Commands::Delete
+        include Transaction
+
         def execute
           deleted = target.to_a
           target.delete

--- a/lib/rom/sql/commands/transaction.rb
+++ b/lib/rom/sql/commands/transaction.rb
@@ -1,0 +1,17 @@
+require 'rom/commands/result'
+
+module ROM
+  module SQL
+    module Commands
+      module Transaction
+        ROM::SQL::Rollback = Class.new(Sequel::Rollback)
+
+        def transaction(options = {}, &block)
+          ROM::Commands::Result::Success.new(
+            relation.dataset.db.transaction(options, &block)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/commands/update.rb
+++ b/lib/rom/sql/commands/update.rb
@@ -1,9 +1,12 @@
 require 'rom/sql/commands'
+require 'rom/sql/commands/transaction'
 
 module ROM
   module SQL
     module Commands
       class Update < ROM::Commands::Update
+        include Transaction
+
         option :original, type: Hash, reader: true
 
         alias_method :to, :call
@@ -45,7 +48,6 @@ module ROM
             tuple
           end
         end
-
       end
     end
   end

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -214,7 +214,8 @@ module ROM
       #
       # @example
       #   users.delete # deletes all
-      #   users.where(name: 'Jane').delete # delete tuples from restricted relation
+      #   users.where(name: 'Jane').delete # delete tuples
+      #                                      from restricted relation
       #
       # @return [Relation]
       #

--- a/spec/integration/commands/delete_spec.rb
+++ b/spec/integration/commands/delete_spec.rb
@@ -21,6 +21,25 @@ describe 'Commands / Delete' do
     rom.relations.users.insert(id: 2, name: 'Jane')
   end
 
+  context '#transaction' do
+    it 'delete in normal way if no error raised' do
+      expect {
+        users.delete.transaction do
+          users.delete.by_name('Jane').call
+        end
+      }.to change { rom.relations.users.count }.by(-1)
+    end
+
+    it 'delete nothing if error was raised' do
+      expect {
+        users.delete.transaction do
+          users.delete.by_name('Jane').call
+          raise ROM::SQL::Rollback
+        end
+      }.to_not change { rom.relations.users.count }
+    end
+  end
+
   it 'raises error when tuple count does not match expectation' do
     result = users.try { users.delete.call }
 

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -27,6 +27,25 @@ describe 'Commands / Update' do
     relation.insert(name: 'Piotr')
   end
 
+  context '#transaction' do
+    it 'update record if there was no errors' do
+      result = users.update.transaction do
+        users.update.by_id(piotr[:id]).set(peter)
+      end
+
+      expect(result.value).to eq([{ id: 1, name: 'Peter' }])
+    end
+
+    it 'updates nothing if error was raised' do
+      users.update.transaction do
+        users.update.by_id(piotr[:id]).set(peter)
+        raise ROM::SQL::Rollback
+      end
+
+      expect(relation.first[:name]).to eq('Piotr')
+    end
+  end
+
   it 'updates everything when there is no original tuple' do
     result = users.try do
       users.update.by_id(piotr[:id]).set(peter)

--- a/spec/unit/migration_tasks_spec.rb
+++ b/spec/unit/migration_tasks_spec.rb
@@ -80,8 +80,8 @@ describe 'MigrationTasks' do
         expect(File).to receive(:write).with(path, /ROM::SQL::Migration/)
 
         expect {
-          Rake::Task["db:create_migration"].execute(Rake::TaskArguments.new(
-            [:name], [name]))
+          Rake::Task["db:create_migration"].execute(
+            Rake::TaskArguments.new([:name], [name]))
         }.to output(path+"\n").to_stdout
       end
 
@@ -90,8 +90,8 @@ describe 'MigrationTasks' do
         expect(File).to receive(:write).with(path, /ROM::SQL::Migration/)
 
         expect {
-          Rake::Task["db:create_migration"].execute(Rake::TaskArguments.new(
-            [:name, :version], [name, version]))
+          Rake::Task["db:create_migration"].execute(
+            Rake::TaskArguments.new([:name, :version], [name, version]))
         }.to output(path+"\n").to_stdout
       end
     end


### PR DESCRIPTION
Basic transaction interface on top of commands. All options for Sequel transactions works: http://sequel.jeremyevans.net/rdoc/files/doc/transactions_rdoc.html

Example:

```ruby
users = rom.commands.users

users.create.transaction do
  users.create.call(...)
end

users.create.transaction do
  users.create.call(...)
  tags.create.transaction do
    tars.craete.call(...)
  end
end

# will create nothing
users.create.transaction do
  users.create.call(...)
  raise Sequel::Rollback
end

# will try again if failure
users.create.transaction(rollback: :reraise) do
  users.create.call(...)
  raise Sequel::Rollback
end
```