### PR TITLE
Use internal ROM interface for inflector

### DIFF
--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -51,7 +51,7 @@ module ROM
       end
 
       # @api public
-      def prefix(name = Inflecto.singularize(table))
+      def prefix(name = Inflector.singularize(table))
         rename(header.prefix(name).to_h)
       end
 

--- a/lib/rom/sql/relation/class_methods.rb
+++ b/lib/rom/sql/relation/class_methods.rb
@@ -22,7 +22,7 @@ module ROM
         end
 
         def many_to_one(name, options = {})
-          new_options = options.merge(relation: Inflecto.pluralize(name).to_sym)
+          new_options = options.merge(relation: Inflector.pluralize(name).to_sym)
           associations << [__method__, name, new_options]
         end
 


### PR DESCRIPTION
With changes merged from rom-rb/rom#158, `rom` now provides an internal API to access an inflector implementation.  This change updates `rom-sql` to use that API and removes any dependency on the `inflecto` gem.