### PR TITLE
[WIP] Add Migrator repository plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'byebug', platforms: :mri
   gem 'rom', '~> 0.6.0.beta', github: 'rom-rb/rom', branch: 'master'
   gem 'virtus'
   gem 'activesupport'

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -1,0 +1,28 @@
+module ROM
+  module SQL
+    module Migration
+      class Migrator
+        include Options
+
+        DEFAULT_PATH = 'db/migrate'.freeze
+
+        option :path, reader: true, default: DEFAULT_PATH
+
+        attr_reader :connection
+
+        def initialize(connection, options = {})
+          super
+          @connection = connection
+        end
+
+        def run(options = {})
+          Sequel::Migrator.run(connection, path.to_s, options)
+        end
+
+        def migration(&block)
+          Sequel.migration(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -5,6 +5,7 @@ module ROM
         include Options
 
         DEFAULT_PATH = 'db/migrate'.freeze
+        VERSION_FORMAT = '%Y%m%d%H%M%S'.freeze
 
         option :path, reader: true, default: DEFAULT_PATH
 
@@ -21,6 +22,25 @@ module ROM
 
         def migration(&block)
           Sequel.migration(&block)
+        end
+
+        def create_file(name, version = generate_version)
+          filename = "#{version}_#{name}.rb"
+          dirname = Pathname(path)
+          fullpath = dirname.join(filename)
+
+          FileUtils.mkdir_p(dirname)
+          File.write(fullpath, migration_file_content)
+
+          fullpath
+        end
+
+        def generate_version
+          Time.now.utc.strftime(VERSION_FORMAT)
+        end
+
+        def migration_file_content
+          File.read(Pathname(__FILE__).dirname.join('template.rb').realpath)
         end
       end
     end

--- a/lib/rom/sql/migration/template.rb
+++ b/lib/rom/sql/migration/template.rb
@@ -1,0 +1,4 @@
+ROM.env.repositories[:default].migration do
+  change do
+  end
+end

--- a/lib/rom/sql/repository.rb
+++ b/lib/rom/sql/repository.rb
@@ -1,11 +1,15 @@
 require 'logger'
 
 require 'rom/repository'
+require 'rom/sql/migration'
 require 'rom/sql/commands'
 
 module ROM
   module SQL
     class Repository < ROM::Repository
+      include Options
+      include Migration
+
       # Return optionally configured logger
       #
       # @return [Object] logger
@@ -51,6 +55,7 @@ module ROM
       def initialize(uri, options = {})
         @connection = connect(uri, options)
         @schema = connection.tables
+        super
       end
 
       # Disconnect from database

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -43,23 +43,8 @@ namespace :db do
       exit
     end
 
-    version ||= Time.now.utc.strftime("%Y%m%d%H%M%S")
+    path = repository.migrator.create_file(*[name, version].compact)
 
-    filename = "#{version}_#{name}.rb"
-    dirname = repository.migrator.path
-    path = File.join(dirname, filename)
-
-    FileUtils.mkdir_p(dirname)
-
-    content = <<-CONTENT
-ROM.env.repositories[:default].migration do
-  change do
-  end
-end
-    CONTENT
-
-    File.write path, content
-
-    puts path
+    puts "<= migration file created #{path}"
   end
 end

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -3,32 +3,38 @@ require "fileutils"
 
 namespace :db do
   desc "Perform migration reset (full erase and migration up)"
-  task reset: :load_setup do
-    ROM::SQL::Migration.run(target: 0)
-    ROM::SQL::Migration.run
+  task reset: :setup do
+    repository = ROM.env.repositories[:default]
+    repository.run_migrations(target: 0)
+    repository.run_migrations
     puts "<= db:reset executed"
   end
 
   desc "Migrate the database (options [version_number])]"
-  task :migrate, [:version] => :load_setup do |_, args|
+  task :migrate, [:version] => :setup do |_, args|
+    repository = ROM.env.repositories[:default]
     version = args[:version]
+
     if version.nil?
-      ROM::SQL::Migration.run
+      repository.run_migrations
       puts "<= db:migrate executed"
     else
-      ROM::SQL::Migration.run(target: version.to_i)
+      repository.run_migrations(target: version.to_i)
       puts "<= db:migrate version=[#{version}] executed"
     end
   end
 
   desc "Perform migration down (erase all data)"
-  task clean: :load_setup do
-    ROM::SQL::Migration.run(target: 0)
+  task clean: :setup do
+    repository = ROM.env.repositories[:default]
+
+    repository.run_migrations(target: 0)
     puts "<= db:clean executed"
   end
 
   desc "Create a migration (parameters: NAME, VERSION)"
-  task :create_migration, [:name, :version] => :load_setup do |_, args|
+  task :create_migration, [:name, :version] => :setup do |_, args|
+    repository = ROM.env.repositories[:default]
     name, version = args[:name], args[:version]
 
     if name.nil?
@@ -40,16 +46,19 @@ namespace :db do
     version ||= Time.now.utc.strftime("%Y%m%d%H%M%S")
 
     filename = "#{version}_#{name}.rb"
-    dirname  = ROM::SQL::Migration.path
-    path     = File.join(dirname, filename)
+    dirname = repository.migrator.path
+    path = File.join(dirname, filename)
 
     FileUtils.mkdir_p(dirname)
-    File.write path, <<-MIGRATION
-ROM::SQL::Migration.create do
+
+    content = <<-CONTENT
+ROM.env.repositories[:default].migration do
   change do
   end
 end
-    MIGRATION
+    CONTENT
+
+    File.write path, content
 
     puts path
   end

--- a/spec/fixtures/migrations/20150403090603_create_carrots.rb
+++ b/spec/fixtures/migrations/20150403090603_create_carrots.rb
@@ -1,4 +1,4 @@
-ROM.env.repository[:default].migration do
+ROM.env.repositories[:default].migration do
   change do
     create_table :carrots do
       primary_key :id

--- a/spec/fixtures/migrations/20150403090603_create_carrots.rb
+++ b/spec/fixtures/migrations/20150403090603_create_carrots.rb
@@ -1,0 +1,8 @@
+ROM.env.repository[:default].migration do
+  change do
+    create_table :carrots do
+      primary_key :id
+      String :name
+    end
+  end
+end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -8,7 +8,9 @@ describe ROM::SQL::Repository do
       subject(:repository) { rom.repositories[:default] }
 
       after do
-        repository.connection.drop_table?(:rabbits)
+        [:rabbits, :carrots].each do |name|
+          repository.connection.drop_table?(name)
+        end
       end
 
       it 'allows creating and running migrations' do

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -48,7 +48,6 @@ describe ROM::SQL::Repository do
       end
 
       it 'runs migrations from a specified directory' do
-        pending 'for some reason sequel picks up incorrect version'
         ROM.env.repositories[:default].run_migrations
       end
     end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe ROM::SQL::Repository do
+  describe 'migration' do
+    include_context 'database setup'
+
+    context 'creating migrations inline' do
+      subject(:repository) { rom.repositories[:default] }
+
+      after do
+        repository.connection.drop_table?(:rabbits)
+      end
+
+      it 'allows creating and running migrations' do
+        migration = repository.migration do
+          up do
+            create_table(:rabbits) do
+              primary_key :id
+              String :name
+            end
+          end
+
+          down do
+            drop_table(:rabbits)
+          end
+        end
+
+        migration.apply(repository.connection, :up)
+
+        expect(repository.connection[:rabbits]).to be_a(Sequel::Dataset)
+
+        migration.apply(repository.connection, :down)
+
+        expect(repository.connection.tables).to_not include(:rabbits)
+      end
+    end
+
+    context 'running migrations from a file system' do
+      let(:migration_dir) do
+        Pathname(__FILE__).dirname.join('../fixtures/migrations').realpath
+      end
+
+      let(:migrator) { ROM::SQL::Migration::Migrator.new(conn, path: migration_dir) }
+
+      before do
+        ROM.setup(:sql, [conn, migrator: migrator])
+        ROM.finalize
+      end
+
+      it 'runs migrations from a specified directory' do
+        pending 'for some reason sequel picks up incorrect version'
+        ROM.env.repositories[:default].run_migrations
+      end
+    end
+  end
+end

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -6,7 +6,9 @@ shared_context 'database setup' do
   let(:setup) { ROM.setup(:sql, conn) }
 
   def drop_tables
-    [:users, :tasks, :tags, :task_tags].each { |name| conn.drop_table?(name) }
+    [:users, :tasks, :tags, :task_tags, :schema_migrations].each do |name|
+      conn.drop_table?(name)
+    end
   end
 
   before do

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -1,12 +1,12 @@
 shared_context 'database setup' do
   subject(:rom) { setup.finalize }
 
-  let(:uri) { 'postgres://localhost/rom' }
+  let(:uri) { DB_URI }
   let(:conn) { Sequel.connect(uri) }
   let(:setup) { ROM.setup(:sql, conn) }
 
   def drop_tables
-    [:users, :tasks, :tags, :task_tags, :schema_migrations].each do |name|
+    [:users, :tasks, :tags, :task_tags, :rabbits, :carrots, :schema_migrations].each do |name|
       conn.drop_table?(name)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@ require 'rom/sql/rake_task'
 # FIXME: why do we need to require it manually??
 require 'sequel/adapters/postgres'
 require 'logger'
+begin
+  require 'byebug'
+rescue LoadError
+end
 
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,12 +19,18 @@ rescue LoadError
 end
 
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))
+DB_URI = 'postgres://localhost/rom'
 
 root = Pathname(__FILE__).dirname
+TMP_PATH = root.join('../tmp').realpath
 
 Dir[root.join('shared/*.rb').to_s].each { |f| require f }
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    FileUtils.rm_r(TMP_PATH.join('test'))
+  end
+
   config.before do
     @constants = Object.constants
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,13 +22,15 @@ LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 DB_URI = 'postgres://localhost/rom'
 
 root = Pathname(__FILE__).dirname
-TMP_PATH = root.join('../tmp').realpath
+TMP_PATH = root.join('../tmp')
 
 Dir[root.join('shared/*.rb').to_s].each { |f| require f }
 
 RSpec.configure do |config|
   config.before(:suite) do
-    FileUtils.rm_r(TMP_PATH.join('test'))
+    tmp_test_dir = TMP_PATH.join('test')
+    FileUtils.rm_r(tmp_test_dir) if File.exist?(tmp_test_dir)
+    FileUtils.mkdir_p(tmp_test_dir)
   end
 
   config.before do

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -20,7 +20,7 @@ describe ROM::SQL::Migration do
     it 'returns default path if non provided' do
       migration.path = nil
 
-      expect(migration.path).to eq ROM::SQL::Migration::DEFAULT_PATH
+      expect(migration.path).to eq ROM::SQL::Migration::Migrator::DEFAULT_PATH
     end
   end
 

--- a/spec/unit/migration_tasks_spec.rb
+++ b/spec/unit/migration_tasks_spec.rb
@@ -77,30 +77,22 @@ describe 'MigrationTasks' do
       let(:filename) { "#{version}_#{name}.rb" }
       let(:path) { File.join(dirname, filename) }
 
-      before do
-        expect(migrator).to receive(:path).and_return(dirname)
-      end
-
       it 'calls proper commands with default VERSION' do
-        time = double(utc: double(strftime: '001'))
-        expect(Time).to receive(:now).and_return(time)
-        expect(FileUtils).to receive(:mkdir_p).with(dirname)
-        expect(File).to receive(:write).with(path, /ROM.env.repositories\[:default\]/)
+        expect(migrator).to receive(:create_file).with(name).and_return(path)
 
         expect {
           Rake::Task["db:create_migration"].execute(
             Rake::TaskArguments.new([:name], [name]))
-        }.to output(path+"\n").to_stdout
+        }.to output("<= migration file created #{path}\n").to_stdout
       end
 
       it 'calls proper commands with manualy set VERSION' do
-        expect(FileUtils).to receive(:mkdir_p).with(dirname)
-        expect(File).to receive(:write).with(path, /ROM.env.repositories\[:default\]/)
+        expect(migrator).to receive(:create_file).with(name, version).and_return(path)
 
         expect {
           Rake::Task["db:create_migration"].execute(
             Rake::TaskArguments.new([:name, :version], [name, version]))
-        }.to output(path+"\n").to_stdout
+        }.to output("<= migration file created #{path}\n").to_stdout
       end
     end
   end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe ROM::SQL::Migration::Migrator do
+  subject(:migrator) { ROM::SQL::Migration::Migrator.new(conn, options) }
+
+  let(:conn) { Sequel.connect(DB_URI) }
+  let(:options) { { path: TMP_PATH.join('test/migrations') } }
+
+  describe '#create_file' do
+    it 'creates a migration file under configured path with specified version and name' do
+      file_path = migrator.create_file('create_users', 1)
+
+      expect(file_path).to eql(migrator.path.join('1_create_users.rb'))
+      expect(File.exist?(file_path)).to be(true)
+      expect(File.read(file_path)).to eql(migrator.migration_file_content)
+    end
+
+    it 'auto-generates version when it is not provided' do
+      file_path = migrator.create_file('create_users')
+
+      expect(file_path.to_s).to match(/.(\d+)_create_users\.rb/)
+      expect(File.exist?(file_path)).to be(true)
+      expect(File.read(file_path)).to eql(migrator.migration_file_content)
+    end
+  end
+end


### PR DESCRIPTION
This makes it possible to inject a migrator to repository which exposes
migration DSL and interface required for running migrations.

This means that the only thing we need to do to use migrations is to
simply setup a repository which removes the `load_setup` task
requirement.