### PR TITLE
raise ROM::NoAssociationError when accessing non-existant relations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem 'byebug', platforms: :mri
-  gem 'rom', '~> 0.6.0.beta', github: 'rom-rb/rom', branch: 'master'
+  gem 'rom', '~> 0.6.0.beta', github: 'pdswan/rom', branch: 'better-association-join-error-message'
   gem 'virtus'
   gem 'activesupport'
   gem 'rspec', '~> 3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem 'byebug', platforms: :mri
-  gem 'rom', '~> 0.6.0.beta', github: 'pdswan/rom', branch: 'better-association-join-error-message'
+  gem 'rom', '~> 0.6.0.beta', github: 'rom-rb/rom', branch: 'master'
   gem 'virtus'
   gem 'activesupport'
   gem 'rspec', '~> 3.1'

--- a/lib/rom/sql.rb
+++ b/lib/rom/sql.rb
@@ -3,6 +3,7 @@ require "rom"
 
 module ROM
   module SQL
+    NoAssociationError = Class.new(StandardError)
     ConstraintError = Class.new(ROM::CommandError)
 
     class DatabaseError < ROM::CommandError

--- a/lib/rom/sql/relation/associations.rb
+++ b/lib/rom/sql/relation/associations.rb
@@ -45,17 +45,23 @@ module ROM
         end
 
         # @api private
-        def graph_join(name, join_type, options = {})
-          assoc = model.association_reflection(name)
+        def graph_join(assoc_name, join_type, options = {})
+          assoc = model.association_reflection(assoc_name)
+
+          if assoc.nil?
+            raise NoAssociationError,
+              "Association #{assoc_name.inspect} has not been " \
+              "defined for relation #{name.inspect}"
+          end
 
           key = assoc[:key]
           type = assoc[:type]
 
           if type == :many_to_many
             select = options[:select] || {}
-            graph_join_many_to_many(name, assoc, select)
+            graph_join_many_to_many(assoc_name, assoc, select)
           else
-            graph_join_other(name, key, type, join_type, options)
+            graph_join_other(assoc_name, key, type, join_type, options)
           end
         end
 

--- a/spec/unit/association_errors_spec.rb
+++ b/spec/unit/association_errors_spec.rb
@@ -13,7 +13,7 @@ describe 'Association errors' do
 
       expect {
         rom.relations.users.with_undefined
-      }.to raise_error ROM::NoAssociationError, 'Association :undefined has not been defined for relation :users'
+      }.to raise_error ROM::SQL::NoAssociationError, 'Association :undefined has not been defined for relation :users'
     end
   end
 end

--- a/spec/unit/association_errors_spec.rb
+++ b/spec/unit/association_errors_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'Association errors' do
+  include_context 'users and tasks'
+
+  describe 'accessing an undefined association' do
+    specify do
+      setup.relation(:users) do
+        def with_undefined
+          association_join(:undefined)
+        end
+      end
+
+      expect {
+        rom.relations.users.with_undefined
+      }.to raise_error ROM::NoAssociationError, 'Association :undefined has not been defined for relation :users'
+    end
+  end
+end
+


### PR DESCRIPTION
raise a more descriptive error when accessing a non-existent association as per https://github.com/rom-rb/rom/issues/173.

depends on https://github.com/rom-rb/rom/pull/210