### PR TITLE
fixed bug in ROM::SQL::Relation::Associations#graph_join

### DIFF
--- a/lib/rom/sql/relation/associations.rb
+++ b/lib/rom/sql/relation/associations.rb
@@ -56,12 +56,13 @@ module ROM
 
           key = assoc[:key]
           type = assoc[:type]
+          table_name = assoc[:class].table_name
 
           if type == :many_to_many
             select = options[:select] || {}
-            graph_join_many_to_many(assoc_name, assoc, select)
+            graph_join_many_to_many(table_name, assoc, select)
           else
-            graph_join_other(assoc_name, key, type, join_type, options)
+            graph_join_other(table_name, key, type, join_type, options)
           end
         end
 

--- a/spec/integration/read_spec.rb
+++ b/spec/integration/read_spec.rb
@@ -5,7 +5,7 @@ describe 'Reading relations' do
   include_context 'users and tasks'
 
   before :each do
-    class Task
+    class Goal
       include Virtus.value_object(coerce: true)
 
       values do
@@ -20,31 +20,34 @@ describe 'Reading relations' do
       values do
         attribute :id, Integer
         attribute :name, String
-        attribute :tasks, Array[Task]
+        attribute :goals, Array[Goal]
       end
     end
 
-    class UserTaskCount
+    class UserGoalCount
       include Virtus.value_object(coerce: true)
 
       values do
         attribute :id, Integer
         attribute :name, String
-        attribute :task_count, Integer
+        attribute :goal_count, Integer
       end
     end
 
-    setup.relation(:tasks)
+    setup.relation(:goals) do
+      register_as :goals
+      dataset :tasks
+    end
 
     setup.relation(:users) do
-      one_to_many :tasks, key: :user_id
+      one_to_many :goals, key: :user_id
 
       def by_name(name)
         where(name: name)
       end
 
-      def with_tasks
-        association_left_join(:tasks, select: [:id, :title])
+      def with_goals
+        association_left_join(:goals, select: [:id, :title])
       end
 
       def all
@@ -52,19 +55,19 @@ describe 'Reading relations' do
       end
     end
 
-    setup.relation(:user_task_counts) do
+    setup.relation(:user_goal_counts) do
       dataset :users
-      register_as :user_task_counts
-      one_to_many :tasks, key: :user_id
+      register_as :user_goal_counts
+      one_to_many :goals, key: :user_id
 
       def all
-        with_tasks.select_group(:users__id, :users__name).select_append {
-          count(:tasks).as(:task_count)
+        with_goals.select_group(:users__id, :users__name).select_append {
+          count(:tasks).as(:goal_count)
         }
       end
 
-      def with_tasks
-        association_left_join(:tasks, select: [:id, :title])
+      def with_goals
+        association_left_join(:goals, select: [:id, :title])
       end
     end
 
@@ -72,36 +75,36 @@ describe 'Reading relations' do
       define(:users) do
         model User
 
-        group :tasks do
-          model Task
+        group :goals do
+          model Goal
 
           attribute :id, from: :tasks_id
           attribute :title
         end
       end
 
-      define(:user_task_counts) do
-        model UserTaskCount
+      define(:user_goal_counts) do
+        model UserGoalCount
       end
     end
   end
 
   it 'loads domain objects' do
-    user = rom.relation(:users).as(:users).with_tasks.by_name('Piotr').to_a.first
+    user = rom.relation(:users).as(:users).with_goals.by_name('Piotr').to_a.first
 
     expect(user).to eql(
       User.new(
-        id: 1, name: 'Piotr', tasks: [Task.new(id: 1, title: 'Finish ROM')]
+        id: 1, name: 'Piotr', goals: [Goal.new(id: 1, title: 'Finish ROM')]
       ))
   end
 
   it 'works with grouping and aggregates' do
-    rom.relations[:tasks].insert(id: 2, user_id: 1, title: 'Get Milk')
+    rom.relations[:goals].insert(id: 2, user_id: 1, title: 'Get Milk')
 
-    users_with_task_count = rom.relation(:user_task_counts).as(:user_task_counts).all
+    users_with_goal_count = rom.relation(:user_goal_counts).as(:user_goal_counts).all
 
-    expect(users_with_task_count.to_a).to eq([
-      UserTaskCount.new(id: 1, name: "Piotr", task_count: 2)
+    expect(users_with_goal_count.to_a).to eq([
+      UserGoalCount.new(id: 1, name: "Piotr", goal_count: 2)
     ])
   end
 end


### PR DESCRIPTION
Used the name of the dataset (db table) instead of the relation's name,
that can differ from it.

See [rom#218](https://github.com/rom-rb/rom/issues/218)