### PR TITLE
Wrap errors  when calling command with []-syntax

### DIFF
--- a/lib/rom/sql/commands/error_wrapper.rb
+++ b/lib/rom/sql/commands/error_wrapper.rb
@@ -13,6 +13,8 @@ module ROM
         rescue *ERROR_MAP.keys => e
           raise ERROR_MAP[e.class], e
         end
+
+        alias :[] :call
       end
     end
   end

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -184,6 +184,13 @@ describe 'Commands / Create' do
     }.to raise_error(ROM::SQL::DatabaseError)
   end
 
+  it 'supports [] syntax instead of call' do
+    expect {
+      Params.attribute :bogus_field
+      users.try { users.create[name: 'some name', bogus_field: 23] }
+    }.to raise_error(ROM::SQL::DatabaseError)
+  end
+
   describe '.associates' do
     it 'sets foreign key prior execution for many tuples' do
       setup.commands(:tasks) do


### PR DESCRIPTION
Fixes rom-rb/rom#236

Note: I'm only testing that [] works for one case, this should probably be changed so that we run all error re-raising tests with both ```[]``` and ```call```.