### PR TITLE
Add `invert` relation operation

### DIFF
--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -199,6 +199,21 @@ module ROM
         __new__(dataset.__send__(__method__, *args, &block))
       end
 
+      # Inverts a request
+      #
+      # @example
+      #   users.exclude(name: 'Jane').invert
+      #
+      #   # this is the same as:
+      #   users.where(name: 'Jane')
+      #
+      # @return [Relation]
+      #
+      # @api public
+      def invert(*args, &block)
+        __new__(dataset.__send__(__method__, *args, &block))
+      end
+
       # Set order for the relation
       #
       # @example

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -29,6 +29,13 @@ describe ROM::Relation do
     end
   end
 
+  describe '#invert' do
+    it 'delegates to dataset and returns a new relation' do
+      expect(users.dataset).to receive(:invert).and_call_original
+      expect(users.invert).to_not eq(users)
+    end
+  end
+
   describe '#map' do
     it 'yields tuples' do
       result = []


### PR DESCRIPTION
Added [Sequel `invert`](http://sequel.jeremyevans.net/rdoc/classes/Sequel/Dataset.html#method-i-invert) to relation operations.

PS. Seems like I cannot push to `rom/rom-sql` directly.