### PR TITLE
Add helper method to set table name on a relation

### DIFF
--- a/lib/rom/sql/relation/class_methods.rb
+++ b/lib/rom/sql/relation/class_methods.rb
@@ -93,12 +93,29 @@ module ROM
           associations << [__method__, name, new_options]
         end
 
+        # Specify the table for the model
+        #
+        # @example
+        #   class Tasks < ROM::Relation[:sql]
+        #     table_name :user_tasks
+        #   end
+        #
+        # @param [Symbol] name The name of the table. Specify a schema
+        #                      like so: :schema_name__table_name
+        #
+        # @api public
+        def table_name(name)
+          @table_name = name
+        end
+
         # Finalize the relation by setting up its associations (if any)
         #
         # @api private
         def finalize(relations, relation)
+          dataset(@table_name) if @table_name
           return unless relation.dataset.db.table_exists?(dataset)
 
+          relation.dataset.opts[:from] = [@table_name] if @table_name
           model.set_dataset(relation.dataset)
           model.dataset.naked!
 

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -7,9 +7,9 @@ shared_context 'database setup' do
   let(:setup) { ROM.setup(:sql, conn) }
 
   def drop_tables
-    [:tasks, :users, :tags, :task_tags, :rabbits, :carrots, :schema_migrations].each do |name|
-      conn.drop_table?(name)
-    end
+    conn.drop_table?(
+      :tasks, :users, :tags, :task_tags, :rabbits, :carrots, :schema_migrations
+    )
   end
 
   before do

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -14,6 +14,16 @@ describe ROM::Relation do
     end
   end
 
+  describe '.table_name' do
+    it 'allows one to set the table name' do
+      setup.relation(:my_tasks) do
+        table_name :tasks
+      end
+
+      expect(rom.relations.my_tasks.model.table_name).to eq :tasks
+    end
+  end
+
   describe '#distinct' do
     it 'delegates to dataset and returns a new relation' do
       expect(users.dataset).to receive(:distinct).with(:name).and_call_original


### PR DESCRIPTION
This is the best implementation I could figure out. I tried to specify the table name using the model syntax  (eg `class Post < Sequel::Model(:my_posts); end`) that Sequel provides but I couldn't figure out how to get a handle on it [at inheritance](https://github.com/rom-rb/rom-sql/blob/b231c11c1cc0b520d7b15bc1b89761fd3b0b9ea5/lib/rom/sql/relation/class_methods.rb#L17).

Is there a better way to do this? It feels a little janky having to set the table name twice in the finalize method.