### PR TITLE
Relation name and join key fixes for :many_to_one

### DIFF
--- a/lib/rom/sql/relation/associations.rb
+++ b/lib/rom/sql/relation/associations.rb
@@ -97,12 +97,12 @@ module ROM
         end
 
         def graph_join_other(name, assoc, type, join_type, options)
-          key = assoc[:key]
+          key           = assoc[:key]
           on_conditions = assoc[:on] || {}
 
           join_keys =
             if type == :many_to_one
-              { primary_key => key }
+              { assoc[:class].primary_key => key }
             else
               { key => primary_key }
             end.merge(on_conditions)

--- a/lib/rom/sql/relation/class_methods.rb
+++ b/lib/rom/sql/relation/class_methods.rb
@@ -88,9 +88,7 @@ module ROM
         #
         # @api public
         def many_to_one(name, options = {})
-          relation_name = Inflector.pluralize(name).to_sym
-          new_options = options.merge(relation: relation_name)
-          associations << [__method__, name, new_options]
+          associations << [__method__, name, { relation: name }.merge(options)]
         end
 
         # Finalize the relation by setting up its associations (if any)

--- a/spec/unit/many_to_one_spec.rb
+++ b/spec/unit/many_to_one_spec.rb
@@ -43,4 +43,18 @@ describe 'Defining many-to-one association' do
       [{ id: 1, title: 'Finish ROM', user: { name: 'Piotr' } }]
     )
   end
+
+  it "joins on specified key" do
+    setup.relation(:task_tags) do
+      many_to_one :tags, key: :tag_id
+
+      def with_tags
+        association_left_join(:tags)
+      end
+    end
+
+    expect(rom.relation(:task_tags).with_tags.to_a).to eq(
+      [{ tag_id: 1, task_id: 1, id: 1, name: "important" }]
+    )
+  end
 end


### PR DESCRIPTION
@solnic Thanks for all your hard work. I'm really enjoying using ROM. I've been using it to make a legacy database a little more consistent and I think I may have found a couple of bugs.

I would love it if you could confirm this is a bug or maybe I'm just _not_ using ROM incorrectly?

1. Can't change `many_to_one` relation name.
2. `many_to_one` uses the wrong tables primary key name.