### PR TITLE
bugfix: many_to_one pluralize default relation option.

### DIFF
--- a/lib/rom/sql/relation/class_methods.rb
+++ b/lib/rom/sql/relation/class_methods.rb
@@ -65,7 +65,7 @@ module ROM
         #
         # @api public
         def many_to_many(name, options = {})
-          associations << [__method__, name, { relation: name }.merge(options)]
+          associations << [__method__, name, { relation: Inflector.pluralize(name).to_sym }.merge(options)]
         end
 
         # Set up a many-to-one association


### PR DESCRIPTION
@gotar @solnic restore default behavior but allows the ability to override relation option.

ref: https://github.com/rom-rb/rom-sql/commit/196d703239e6bad2ac26508ca847f7b32fa1896b