### PR TITLE
Add `:extensions` option to Gateway

### DIFF
--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -67,6 +67,7 @@ module ROM
 
         @connection = connect(uri, conn_options)
         @schema = connection.tables
+        add_extensions(Array(options[:extensions])) if options[:extensions]
 
         super(uri, options.reject { |k,_| conn_options.keys.include?(k) })
       end
@@ -160,6 +161,13 @@ module ROM
         else
           ::Sequel.connect(uri.to_s, *args)
         end
+      end
+
+      # Add extensions to the database connection
+      #
+      # @api private
+      def add_extensions(exts)
+        connection.extension(*exts)
       end
     end
   end

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -35,6 +35,15 @@ describe ROM::SQL::Gateway do
 
       expect(gateway.options).to eql(migrator: migrator)
     end
+
+    it 'allows extensions' do
+      extensions = [:pg_array, :pg_enum]
+      connection = Sequel.connect uri
+
+      expect(connection).to receive(:extension).with(:pg_array, :pg_enum)
+
+      ROM::SQL::Gateway.new(connection, extensions: extensions)
+    end
   end
 
   describe '#disconnect' do


### PR DESCRIPTION
- Array of extensions is passed onto the connection.

Example Usage:
`ROM.setup(:sql, [‘postgres://localhost/db', extensions: [:pg_enum, :pg_array])`

@solnic how would you suggest testing and documented this?