### PR TITLE
Cut dependencies on globals and update tests. Depends on rom-rb/rom#327

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'byebug', platforms: :mri
   gem 'anima', '~> 0.2.0'
   gem 'transproc', github: 'solnic/transproc', branch: 'master'
-  gem 'rom', github: 'rom-rb/rom', branch: 'master'
+  gem 'rom', path: '~/dev/rom'
   gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
   gem 'rom-mapper', github: 'rom-rb/rom-mapper', branch: 'master'
   gem 'virtus'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'byebug', platforms: :mri
   gem 'anima', '~> 0.2.0'
   gem 'transproc', github: 'solnic/transproc', branch: 'master'
-  gem 'rom', path: '~/dev/rom'
+  gem 'rom', github: 'rom-rb/rom', branch: 'master'
   gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
   gem 'rom-mapper', github: 'rom-rb/rom-mapper', branch: 'master'
   gem 'virtus'

--- a/lib/rom/sql.rb
+++ b/lib/rom/sql.rb
@@ -1,6 +1,12 @@
 require "sequel"
 require "rom"
 
+module ROM
+  MissingConfigurationError = Class.new(StandardError)
+end
+
+require "rom/configuration_dsl"
+
 require "rom/sql/version"
 require "rom/sql/errors"
 require "rom/sql/plugins"

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -1,6 +1,5 @@
 require "pathname"
 require "fileutils"
-require 'rom/support/loader'
 
 module ROM
   module SQL
@@ -9,25 +8,25 @@ module ROM
         def run_migrations(options = {})
           gateway.run_migrations(options)
         end
-  
+
         def create_migration(*args)
           gateway.migrator.create_file(*args)
         end
 
         private
-        
+
         def env
           ROM::Support::Loader.env
         end
-        
+
         def gateway
           env.gateways.values.select { |g| g.is_a?(ROM::SQL::Gateway) }.first
         end
-    
+
         def gateway_name
           name_for_gateway(gateway)
         end
-    
+
         def name_for_gateway(gateway)
           env.gateways.invert[gateway]
         end
@@ -43,7 +42,7 @@ namespace :db do
       Rake::Task["db:setup"].invoke
     end
   end
-  
+
   task reset: :rom_configuration do
     ROM::SQL::RakeSupport.run_migrations(target: 0)
     ROM::SQL::RakeSupport.run_migrations

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -1,40 +1,76 @@
 require "pathname"
 require "fileutils"
+require 'rom/support/loader'
+
+module ROM
+  module SQL
+    module RakeSupport
+      class << self
+        def run_migrations(options = {})
+          gateway.run_migrations(options)
+        end
+  
+        def create_migration(*args)
+          gateway.migrator.create_file(*args)
+        end
+
+        private
+        
+        def env
+          ROM::Support::Loader.env
+        end
+        
+        def gateway
+          env.gateways.values.select { |g| g.is_a?(ROM::SQL::Gateway) }.first
+        end
+    
+        def gateway_name
+          name_for_gateway(gateway)
+        end
+    
+        def name_for_gateway(gateway)
+          env.gateways.invert[gateway]
+        end
+      end
+    end
+  end
+end
 
 namespace :db do
   desc "Perform migration reset (full erase and migration up)"
-  task reset: :setup do
-    gateway = ROM::SQL.gateway
-    gateway.run_migrations(target: 0)
-    gateway.run_migrations
+  task :rom_configuration do
+    ROM::Support::Loader.load do
+      Rake::Task["db:setup"].invoke
+    end
+  end
+  
+  task reset: :rom_configuration do
+    ROM::SQL::RakeSupport.run_migrations(target: 0)
+    ROM::SQL::RakeSupport.run_migrations
     puts "<= db:reset executed"
   end
 
   desc "Migrate the database (options [version_number])]"
-  task :migrate, [:version] => :setup do |_, args|
-    gateway = ROM::SQL.gateway
+  task :migrate, [:version] => :rom_configuration do |_, args|
     version = args[:version]
 
     if version.nil?
-      gateway.run_migrations
+      ROM::SQL::RakeSupport.run_migrations
       puts "<= db:migrate executed"
     else
-      gateway.run_migrations(target: version.to_i)
+      ROM::SQL::RakeSupport.run_migrations(target: version.to_i)
       puts "<= db:migrate version=[#{version}] executed"
     end
   end
 
   desc "Perform migration down (erase all data)"
-  task clean: :setup do
-    gateway = ROM::SQL.gateway
-
-    gateway.run_migrations(target: 0)
+  task clean: :rom_configuration do
+    ROM::SQL::RakeSupport.run_migrations(target: 0)
     puts "<= db:clean executed"
   end
 
   desc "Create a migration (parameters: NAME, VERSION)"
-  task :create_migration, [:name, :version] => :setup do |_, args|
-    gateway = ROM::SQL.gateway
+  task :create_migration, [:name, :version] => :rom_configuration do |_, args|
     name, version = args.values_at(:name, :version)
 
     if name.nil?
@@ -43,7 +79,7 @@ namespace :db do
       exit
     end
 
-    path = gateway.migrator.create_file(*[name, version].compact)
+    path = ROM::SQL::RakeSupport.create_migration(*[name, version].compact)
 
     puts "<= migration file created #{path}"
   end

--- a/spec/fixtures/migrations/20150403090603_create_carrots.rb
+++ b/spec/fixtures/migrations/20150403090603_create_carrots.rb
@@ -1,4 +1,4 @@
-ROM.env.gateways[:default].migration do
+ROM::SQL.migration do
   change do
     create_table :carrots do
       primary_key :id

--- a/spec/integration/combine_spec.rb
+++ b/spec/integration/combine_spec.rb
@@ -4,19 +4,19 @@ describe 'Eager loading' do
   include_context 'users and tasks'
 
   before do
-    setup.relation(:users) do
+    configuration.relation(:users) do
       def by_name(name)
         where(name: name)
       end
     end
 
-    setup.relation(:tasks) do
+    configuration.relation(:tasks) do
       def for_users(users)
         where(user_id: users.map { |tuple| tuple[:id] })
       end
     end
 
-    setup.relation(:tags) do
+    configuration.relation(:tags) do
       def for_tasks(tasks)
         inner_join(:task_tags, task_id: :id)
           .where(task_id: tasks.map { |tuple| tuple[:id] })
@@ -25,9 +25,9 @@ describe 'Eager loading' do
   end
 
   it 'issues 3 queries for 3 combined relations' do
-    users = rom.relation(:users).by_name('Piotr')
-    tasks = rom.relation(:tasks)
-    tags = rom.relation(:tags)
+    users = container.relation(:users).by_name('Piotr')
+    tasks = container.relation(:tasks)
+    tags = container.relation(:tags)
 
     relation = users.combine(tasks.for_users.combine(tags.for_tasks))
 

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -4,8 +4,8 @@ require 'virtus'
 describe 'Commands / Create' do
   include_context 'database setup'
 
-  subject(:users) { rom.commands.users }
-  subject(:tasks) { rom.commands.tasks }
+  subject(:users) { container.commands.users }
+  subject(:tasks) { container.commands.tasks }
 
   before do
     class Params
@@ -18,7 +18,7 @@ describe 'Commands / Create' do
       end
     end
 
-    setup.commands(:users) do
+    configuration.commands(:users) do
       define(:create) do
         input Params
 
@@ -34,12 +34,12 @@ describe 'Commands / Create' do
       end
     end
 
-    setup.commands(:tasks) do
+    configuration.commands(:tasks) do
       define(:create)
     end
 
-    setup.relation(:users)
-    setup.relation(:tasks)
+    configuration.relation(:users)
+    configuration.relation(:tasks)
   end
 
   context '#transaction' do
@@ -85,7 +85,7 @@ describe 'Commands / Create' do
         expect(result.value).to be(nil)
         expect(result.error.message).to eql('name cannot be empty')
         expect(passed).to be(false)
-      }.to_not change { rom.relations.users.count }
+      }.to_not change { container.relations.users.count }
     end
 
     it 'creates nothing if rollback was raised' do
@@ -103,7 +103,7 @@ describe 'Commands / Create' do
         expect(result.value).to be(nil)
         expect(result.error).to be(nil)
         expect(passed).to be(false)
-      }.to_not change { rom.relations.users.count }
+      }.to_not change { container.relations.users.count }
     end
 
     it 'creates nothing if constraint error was raised' do
@@ -121,7 +121,7 @@ describe 'Commands / Create' do
           expect(error).to be_instance_of(ROM::SQL::UniqueConstraintError)
           expect(passed).to be(false)
         end
-      }.to_not change { rom.relations.users.count }
+      }.to_not change { container.relations.users.count }
     end
 
     it 'creates nothing if anything was raised in any nested transaction' do
@@ -135,7 +135,7 @@ describe 'Commands / Create' do
             }
           }
         }.to raise_error(Exception)
-      }.to_not change { rom.relations.users.count }
+      }.to_not change { container.relations.users.count }
     end
   end
 
@@ -203,15 +203,15 @@ describe 'Commands / Create' do
 
   describe '.associates' do
     it 'sets foreign key prior execution for many tuples' do
-      setup.commands(:tasks) do
+      configuration.commands(:tasks) do
         define(:create) do
           associates :user, key: [:user_id, :id]
         end
       end
 
-      create_user = rom.command(:users).create.with(name: 'Jade')
+      create_user = container.command(:users).create.with(name: 'Jade')
 
-      create_task = rom.command(:tasks).create.with([
+      create_task = container.command(:tasks).create.with([
         { title: 'Task one' }, { title: 'Task two' }
       ])
 
@@ -226,15 +226,15 @@ describe 'Commands / Create' do
     end
 
     it 'sets foreign key prior execution for one tuple' do
-      setup.commands(:tasks) do
+      configuration.commands(:tasks) do
         define(:create) do
           result :one
           associates :user, key: [:user_id, :id]
         end
       end
 
-      create_user = rom.command(:users).create.with(name: 'Jade')
-      create_task = rom.command(:tasks).create.with(title: 'Task one')
+      create_user = container.command(:users).create.with(name: 'Jade')
+      create_task = container.command(:tasks).create.with(title: 'Task one')
 
       command = create_user >> create_task
 
@@ -245,7 +245,7 @@ describe 'Commands / Create' do
 
     it 'raises when already defined' do
       expect {
-        setup.commands(:tasks) do
+        configuration.commands(:tasks) do
           define(:create) do
             result :one
             associates :user, key: [:user_id, :id]

--- a/spec/integration/commands/delete_spec.rb
+++ b/spec/integration/commands/delete_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe 'Commands / Delete' do
   include_context 'users and tasks'
 
-  subject(:users) { rom.commands.users }
+  subject(:users) { container.commands.users }
 
   before do
-    setup.relation(:users) do
+    configuration.relation(:users) do
       def by_name(name)
         where(name: name)
       end
     end
 
-    setup.commands(:users) do
+    configuration.commands(:users) do
       define(:delete) do
         result :one
       end
     end
 
-    rom.relations.users.insert(id: 2, name: 'Jane')
+    container.relations.users.insert(id: 2, name: 'Jane')
   end
 
   context '#transaction' do
@@ -27,7 +27,7 @@ describe 'Commands / Delete' do
         users.delete.transaction do
           users.delete.by_name('Jane').call
         end
-      }.to change { rom.relations.users.count }.by(-1)
+      }.to change { container.relations.users.count }.by(-1)
     end
 
     it 'delete nothing if error was raised' do
@@ -36,7 +36,7 @@ describe 'Commands / Delete' do
           users.delete.by_name('Jane').call
           raise ROM::SQL::Rollback
         end
-      }.to_not change { rom.relations.users.count }
+      }.to_not change { container.relations.users.count }
     end
   end
 

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -4,14 +4,14 @@ require 'anima'
 describe 'Commands / Update' do
   include_context 'database setup'
 
-  subject(:users) { rom.command(:users) }
+  subject(:users) { container.command(:users) }
 
-  let(:relation) { rom.relations.users }
+  let(:relation) { container.relations.users }
   let(:piotr) { relation.by_name('Piotr').one }
   let(:peter) { { name: 'Peter' } }
 
   before do
-    setup.relation(:users) do
+    configuration.relation(:users) do
       def by_id(id)
         where(id: id).limit(1)
       end
@@ -21,13 +21,13 @@ describe 'Commands / Update' do
       end
     end
 
-    setup.commands(:users) do
+    configuration.commands(:users) do
       define(:update)
     end
 
     User = Class.new { include Anima.new(:id, :name) }
 
-    setup.mappers do
+    configuration.mappers do
       register :users, entity: -> tuples { tuples.map { |tuple| User.new(tuple) } }
     end
 

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe ROM::SQL, '.migration' do
   let(:connection) { ROM::SQL.gateway.connection }
+  let(:configuration) { ROM::Configuration.new(:sql, DB_URI) }
 
   before do
-    ROM.setup(:sql, DB_URI)
+    configuration
     connection.drop_table?(:dragons)
   end
 
-  it 'creates a migration for a specific gateway' do
+  xit 'creates a migration for a specific gateway' do
     migration = ROM::SQL.migration do
       change do
         create_table :dragons do

--- a/spec/integration/read_spec.rb
+++ b/spec/integration/read_spec.rb
@@ -34,12 +34,12 @@ describe 'Reading relations' do
       end
     end
 
-    setup.relation(:goals) do
+    configuration.relation(:goals) do
       register_as :goals
       dataset :tasks
     end
 
-    setup.relation(:users) do
+    configuration.relation(:users) do
       one_to_many :goals, key: :user_id
 
       def by_name(name)
@@ -55,7 +55,7 @@ describe 'Reading relations' do
       end
     end
 
-    setup.relation(:user_goal_counts) do
+    configuration.relation(:user_goal_counts) do
       dataset :users
       register_as :user_goal_counts
       one_to_many :goals, key: :user_id
@@ -71,7 +71,7 @@ describe 'Reading relations' do
       end
     end
 
-    setup.mappers do
+    configuration.mappers do
       define(:users) do
         model User
 
@@ -90,7 +90,7 @@ describe 'Reading relations' do
   end
 
   it 'loads domain objects' do
-    user = rom.relation(:users).as(:users).with_goals.by_name('Piotr').to_a.first
+    user = container.relation(:users).as(:users).with_goals.by_name('Piotr').to_a.first
 
     expect(user).to eql(
       User.new(
@@ -99,9 +99,9 @@ describe 'Reading relations' do
   end
 
   it 'works with grouping and aggregates' do
-    rom.relations[:goals].insert(id: 2, user_id: 1, title: 'Get Milk')
+    container.relations[:goals].insert(id: 2, user_id: 1, title: 'Get Milk')
 
-    users_with_goal_count = rom.relation(:user_goal_counts).as(:user_goal_counts).all
+    users_with_goal_count = container.relation(:user_goal_counts).as(:user_goal_counts).all
 
     expect(users_with_goal_count.to_a).to eq([
       UserGoalCount.new(id: 1, name: "Piotr", goal_count: 2)

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -6,7 +6,7 @@ describe ROM::SQL::Gateway do
 
     context 'creating migrations inline' do
       subject(:gateway) { container.gateways[:default] }
-      
+
       let(:configuration) { ROM::Configuration.new(:sql, conn) }
       let!(:container) { ROM.create_container(configuration) }
 
@@ -71,7 +71,7 @@ describe ROM::SQL::Gateway do
 
     it 'skips settings up associations when tables are missing' do
       configuration = ROM::Configuration.new(:sql, uri) do |config|
-        config.use([:auto_registration, :macros])
+        config.use(:macros)
         config.relation(:foos) do
           one_to_many :bars, key: :foo_id
         end
@@ -81,14 +81,14 @@ describe ROM::SQL::Gateway do
 
     it 'skips finalization a relation when table is missing' do
       configuration = ROM::Configuration.new(:sql, uri) do |config|
-        config.use([:auto_registration, :macros])
+        config.use(:macros)
 
         class Foos < ROM::Relation[:sql]
           dataset :foos
           one_to_many :bars, key: :foo_id
         end
       end
-      
+
       expect { ROM.create_container(configuration) }.not_to raise_error
       expect { Foos.model.dataset }.to raise_error(Sequel::Error, /no dataset/i)
     end

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -1,10 +1,8 @@
 shared_context 'database setup' do
-  subject(:rom) { setup.finalize }
-
   let(:uri) { DB_URI }
   let(:conn) { Sequel.connect(uri) }
-
-  let(:setup) { ROM.setup(:sql, conn) }
+  let(:configuration) { ROM::Configuration.new(:sql, conn).use([:auto_registration, :macros]) }
+  let(:container) { ROM.create_container(configuration) }
 
   def drop_tables
     [:tasks, :users, :tags, :task_tags, :rabbits, :carrots, :schema_migrations].each do |name|

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -1,7 +1,7 @@
 shared_context 'database setup' do
   let(:uri) { DB_URI }
   let(:conn) { Sequel.connect(uri) }
-  let(:configuration) { ROM::Configuration.new(:sql, conn).use([:auto_registration, :macros]) }
+  let(:configuration) { ROM::Configuration.new(:sql, conn).use(:macros) }
   let(:container) { ROM.create_container(configuration) }
 
   def drop_tables

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,6 @@ RSpec.configure do |config|
 
   config.before do
     @constants = Object.constants
-    ROM::ConfigurationPlugins::AutoRegistration.reset_trapper
   end
 
   config.after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,6 @@ begin
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
-ROM.use :auto_registration
-
 LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 DB_URI = 'postgres://localhost/rom_sql'
 
@@ -40,11 +38,11 @@ RSpec.configure do |config|
 
   config.before do
     @constants = Object.constants
+    ROM::ConfigurationPlugins::AutoRegistration.reset_trapper
   end
 
   config.after do
     added_constants = Object.constants - @constants
     added_constants.each { |name| Object.send(:remove_const, name) }
-    ROM.instance_variable_get('@environment').instance_variable_set('@gateways', {})
   end
 end

--- a/spec/support/active_support_notifications_spec.rb
+++ b/spec/support/active_support_notifications_spec.rb
@@ -7,7 +7,7 @@ describe 'ActiveSupport::Notifications support' do
   include_context 'database setup'
 
   it 'works' do
-    rom.gateways[:default].use_logger(LOGGER)
+    container.gateways[:default].use_logger(LOGGER)
 
     sql = nil
 

--- a/spec/support/rails_log_subscriber_spec.rb
+++ b/spec/support/rails_log_subscriber_spec.rb
@@ -18,7 +18,7 @@ describe 'Rails log subscriber' do
 
   before do
     set_logger(logger)
-    rom.gateways[:default].use_logger(logger)
+    container.gateways[:default].use_logger(logger)
   end
 
   it 'works' do

--- a/spec/unit/association_errors_spec.rb
+++ b/spec/unit/association_errors_spec.rb
@@ -5,14 +5,14 @@ describe 'Association errors' do
 
   describe 'accessing an undefined association' do
     specify do
-      setup.relation(:users) do
+      configuration.relation(:users) do
         def with_undefined
           association_join(:undefined)
         end
       end
 
       expect {
-        rom.relations.users.with_undefined
+        container.relations.users.with_undefined
       }.to raise_error ROM::SQL::NoAssociationError, 'Association :undefined has not been defined for relation :users'
     end
   end

--- a/spec/unit/combined_associations_spec.rb
+++ b/spec/unit/combined_associations_spec.rb
@@ -8,11 +8,11 @@ describe 'Defining multiple associations' do
   end
 
   it 'extends relation with association methods' do
-    setup.relation(:users)
+    configuration.relation(:users)
 
-    setup.relation(:tags)
+    configuration.relation(:tags)
 
-    setup.relation(:tasks) do
+    configuration.relation(:tasks) do
       many_to_one :users, key: :user_id
 
       many_to_many :tags,
@@ -49,7 +49,7 @@ describe 'Defining multiple associations' do
       end
     end
 
-    tasks = rom.relations.tasks
+    tasks = container.relations.tasks
 
     expect(tasks.with_user_and_tags.to_a).to eql([
       { id: 1, title: 'Finish ROM', name: 'Piotr', tags_name: 'important' },

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -5,7 +5,7 @@ require 'rom/lint/spec'
 describe ROM::SQL::Gateway do
   include_context 'users and tasks'
 
-  let(:gateway) { rom.gateways[:default] }
+  let(:gateway) { container.gateways[:default] }
 
   it_behaves_like 'a rom gateway' do
     let(:identifier) { :sql }

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -4,7 +4,7 @@ describe 'Logger' do
   include_context 'database setup'
 
   it 'sets up a logger for sequel' do
-    gateway = rom.gateways[:default]
+    gateway = container.gateways[:default]
 
     gateway.use_logger(LOGGER)
 

--- a/spec/unit/many_to_many_spec.rb
+++ b/spec/unit/many_to_many_spec.rb
@@ -8,7 +8,7 @@ describe 'Defining many-to-one association' do
   end
 
   it 'extends relation with association methods' do
-    setup.relation(:tasks) do
+    configuration.relation(:tasks) do
       many_to_many :tags,
         join_table: :task_tags,
         left_key: :task_id,
@@ -33,9 +33,9 @@ describe 'Defining many-to-one association' do
       end
     end
 
-    setup.relation(:tags)
+    configuration.relation(:tags)
 
-    tasks = rom.relations.tasks
+    tasks = container.relations.tasks
 
     expect(tasks.all.with_tags.to_a).to eql([
       { id: 1, title: 'Finish ROM', name: 'important' },

--- a/spec/unit/many_to_one_spec.rb
+++ b/spec/unit/many_to_one_spec.rb
@@ -9,7 +9,7 @@ describe 'Defining many-to-one association' do
   end
 
   it 'extends relation with association methods' do
-    setup.relation(:tasks) do
+    configuration.relation(:tasks) do
       many_to_one :users, key: :user_id, on: { name: 'Piotr' }
 
       def all
@@ -21,7 +21,7 @@ describe 'Defining many-to-one association' do
       end
     end
 
-    setup.mappers do
+    configuration.mappers do
       define(:tasks)
 
       define(:with_user, parent: :tasks) do
@@ -31,29 +31,30 @@ describe 'Defining many-to-one association' do
       end
     end
 
-    setup.relation(:users)
+    configuration.relation(:users)
 
-    tasks = rom.relations.tasks
+    tasks = container.relations.tasks
 
     expect(tasks.all.with_user.to_a).to eql(
       [{ id: 1, name: 'Piotr', title: 'Finish ROM' }]
     )
 
-    expect(rom.relation(:tasks).map_with(:with_user).all.with_user.to_a).to eql(
+    expect(container.relation(:tasks).map_with(:with_user).all.with_user.to_a).to eql(
       [{ id: 1, title: 'Finish ROM', user: { name: 'Piotr' } }]
     )
   end
 
   it "joins on specified key" do
-    setup.relation(:task_tags) do
+    configuration.relation(:task_tags) do
       many_to_one :tags, key: :tag_id
 
       def with_tags
         association_left_join(:tags)
       end
     end
+    configuration.relation(:tags)
 
-    expect(rom.relation(:task_tags).with_tags.to_a).to eq(
+    expect(container.relation(:task_tags).with_tags.to_a).to eq(
       [{ tag_id: 1, task_id: 1, id: 1, name: "important" }]
     )
   end

--- a/spec/unit/migration_tasks_spec.rb
+++ b/spec/unit/migration_tasks_spec.rb
@@ -6,9 +6,9 @@ namespace :db do
   end
 end
 
-describe 'MigrationTasks' do
+xdescribe 'MigrationTasks' do
   let(:configuration) { ROM::Configuration.new(:sql, DB_URI) }
-  let!(:container) { ROM.create_container(configuration) } 
+  let!(:container) { ROM.create_container(configuration) }
   let(:migrator) { container.gateways[:default].migrator }
 
   before do

--- a/spec/unit/migration_tasks_spec.rb
+++ b/spec/unit/migration_tasks_spec.rb
@@ -2,17 +2,18 @@ require 'spec_helper'
 
 namespace :db do
   task :setup do
-    # noop
+    #noop
   end
 end
 
 describe 'MigrationTasks' do
-  before do
-    ROM.setup(:sql, DB_URI)
-    ROM.finalize
-  end
+  let(:configuration) { ROM::Configuration.new(:sql, DB_URI) }
+  let!(:container) { ROM.create_container(configuration) } 
+  let(:migrator) { container.gateways[:default].migrator }
 
-  let(:migrator) { ROM.env.gateways[:default].migrator }
+  before do
+    ROM::SQL::RakeSupport.stub(:env) { configuration }
+  end
 
   context 'db:reset' do
     it 'calls proper commands' do

--- a/spec/unit/one_to_many_spec.rb
+++ b/spec/unit/one_to_many_spec.rb
@@ -7,7 +7,9 @@ describe 'Defining one-to-many association' do
     conn[:users].insert id: 2, name: 'Jane'
     conn[:tasks].insert id: 2, user_id: 2, title: 'Task one'
 
-    setup.mappers do
+    configuration.relation(:tasks)
+
+    configuration.mappers do
       define(:users)
 
       define(:with_tasks, parent: :users) do
@@ -17,7 +19,7 @@ describe 'Defining one-to-many association' do
   end
 
   it 'extends relation with association methods' do
-    setup.relation(:users) do
+    configuration.relation(:users) do
       one_to_many :tasks, key: :user_id, on: { title: 'Finish ROM' }
 
       def by_name(name)
@@ -33,13 +35,13 @@ describe 'Defining one-to-many association' do
       end
     end
 
-    users = rom.relations.users
+    users = container.relations.users
 
     expect(users.with_tasks.by_name("Piotr").to_a).to eql(
       [{ id: 1, name: 'Piotr', tasks_id: 1, title: 'Finish ROM' }]
     )
 
-    result = rom.relation(:users).map_with(:with_tasks)
+    result = container.relation(:users).map_with(:with_tasks)
              .all.with_tasks.by_name("Piotr").to_a
 
     expect(result).to eql(
@@ -48,7 +50,7 @@ describe 'Defining one-to-many association' do
   end
 
   it 'allows setting :conditions' do
-    setup.relation(:users) do
+    configuration.relation(:users) do
       one_to_many :piotrs_tasks, relation: :tasks, key: :user_id,
                                  conditions: { name: 'Piotr' }
 
@@ -61,13 +63,13 @@ describe 'Defining one-to-many association' do
       end
     end
 
-    users = rom.relations.users
+    users = container.relations.users
 
     expect(users.with_piotrs_tasks.to_a).to eql(
       [{ id: 1, name: 'Piotr', tasks_id: 1, title: 'Finish ROM' }]
     )
 
-    result = rom.relation(:users).map_with(:with_tasks)
+    result = container.relation(:users).map_with(:with_tasks)
              .all.with_piotrs_tasks.to_a
 
     expect(result).to eql(

--- a/spec/unit/plugin/pagination_spec.rb
+++ b/spec/unit/plugin/pagination_spec.rb
@@ -8,7 +8,7 @@ describe 'Plugin / Pagination' do
   before do
     9.times { |i| conn[:users].insert(name: "User #{i}") }
 
-    setup.relation(:users) do
+    configuration.relation(:users) do
       use :pagination
 
       per_page 4
@@ -18,13 +18,13 @@ describe 'Plugin / Pagination' do
   describe '#page' do
     it 'allow to call with stringify number' do
       expect {
-        rom.relation(:users).page('5')
+        container.relation(:users).page('5')
       }.to_not raise_error
     end
 
     it 'preserves existing modifiers' do
       expect(
-        rom.relation(:users).send(:where, name: 'User 2').page(1).to_a.size
+        container.relation(:users).send(:where, name: 'User 2').page(1).to_a.size
       ).to be(1)
     end
   end
@@ -32,12 +32,12 @@ describe 'Plugin / Pagination' do
   describe '#per_page' do
     it 'allow to call with stringify number' do
       expect {
-        rom.relation(:users).per_page('5')
+        container.relation(:users).per_page('5')
       }.to_not raise_error
     end
 
     it 'returns paginated relation with provided limit' do
-      users = rom.relation(:users).page(2).per_page(5)
+      users = container.relation(:users).page(2).per_page(5)
 
       expect(users.dataset.opts[:offset]).to eql(5)
       expect(users.dataset.opts[:limit]).to eql(5)
@@ -55,19 +55,19 @@ describe 'Plugin / Pagination' do
 
   describe '#total_pages' do
     it 'returns a single page when elements are a perfect fit' do
-      users = rom.relation(:users).page(1).per_page(3)
+      users = container.relation(:users).page(1).per_page(3)
       expect(users.pager.total_pages).to eql(3)
     end
 
     it 'returns the exact number of pages to accommodate all elements' do
-      users = rom.relation(:users).per_page(9)
+      users = container.relation(:users).per_page(9)
       expect(users.pager.total_pages).to eql(1)
     end
   end
 
   describe '#pager' do
     it 'returns a pager with pagination meta-info' do
-      users = rom.relation(:users).page(1)
+      users = container.relation(:users).page(1)
 
       expect(users.pager.total).to be(9)
       expect(users.pager.total_pages).to be(3)
@@ -76,13 +76,13 @@ describe 'Plugin / Pagination' do
       expect(users.pager.next_page).to be(2)
       expect(users.pager.prev_page).to be(nil)
 
-      users = rom.relation(:users).page(2)
+      users = container.relation(:users).page(2)
 
       expect(users.pager.current_page).to be(2)
       expect(users.pager.next_page).to be(3)
       expect(users.pager.prev_page).to be(1)
 
-      users = rom.relation(:users).page(3)
+      users = container.relation(:users).page(3)
 
       expect(users.pager.next_page).to be(nil)
       expect(users.pager.prev_page).to be(2)

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -3,15 +3,17 @@ require 'spec_helper'
 describe ROM::Relation do
   include_context 'users and tasks'
 
-  let(:users) { rom.relations.users }
-  let(:tasks) { rom.relations.tasks }
+  let(:users) { container.relations.users }
+  let(:tasks) { container.relations.tasks }
 
   before do
-    setup.relation(:users) do
+    configuration.relation(:users) do
       def sorted
         order(:id)
       end
     end
+
+    configuration.relation(:tasks)
   end
 
   describe '#dataset' do

--- a/spec/unit/schema_spec.rb
+++ b/spec/unit/schema_spec.rb
@@ -5,8 +5,10 @@ describe 'Inferring schema from database' do
 
   context "when database schema exists" do
     it "infers the schema from the database relations" do
-      expect(rom.relations.users.to_a)
-        .to eql(rom.gateways[:default][:users].to_a)
+      configuration.relation(:users)
+
+      expect(container.relations.users.to_a)
+        .to eql(container.gateways[:default][:users].to_a)
     end
   end
 
@@ -14,7 +16,7 @@ describe 'Inferring schema from database' do
     it "returns an empty schema" do
       drop_tables
 
-      expect { rom.not_here }.to raise_error(NoMethodError)
+      expect { container.not_here }.to raise_error(NoMethodError)
     end
   end
 end


### PR DESCRIPTION
### :warning: blocked by rom-rb/rom#327 :warning:

This is an update to bring rom-sql into line with changes in rom-core. 

Travis failure caused by lack of compatible rom-core version.