### PR TITLE
Allow to check for pending migrations

### DIFF
--- a/lib/rom/sql/migration.rb
+++ b/lib/rom/sql/migration.rb
@@ -55,6 +55,13 @@ module ROM
         end
       end
 
+      # @see ROM::SQL::Migration.pending?
+      #
+      # @api public
+      def pending_migrations?
+        migrator.pending?
+      end
+
       # @see ROM::SQL.migration
       #
       # @api public

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -20,6 +20,10 @@ module ROM
           Sequel::Migrator.run(connection, path.to_s, options)
         end
 
+        def pending?
+          !Sequel::Migrator.is_current?(connection, path.to_s)
+        end
+
         def migration(&block)
           Sequel.migration(&block)
         end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -43,6 +43,8 @@ describe ROM::SQL::Gateway do
     end
 
     context 'running migrations from a file system' do
+      include_context 'database setup'
+
       let(:migration_dir) do
         Pathname(__FILE__).dirname.join('../fixtures/migrations').realpath
       end
@@ -52,6 +54,15 @@ describe ROM::SQL::Gateway do
       before do
         ROM.setup(:sql, [conn, migrator: migrator])
         ROM.finalize
+      end
+
+      it 'returns true for pending migrations' do
+        expect(ROM.env.gateways[:default].pending_migrations?).to be_truthy
+      end
+
+      it 'returns false for non pending migrations' do
+        ROM.env.gateways[:default].run_migrations
+        expect(ROM.env.gateways[:default].pending_migrations?).to be_falsy
       end
 
       it 'runs migrations from a specified directory' do


### PR DESCRIPTION
Using internal Sequel mechanism allow to check if there are pending
migrations:

```
ROM.env.gateways[:default].pending_migrations?
```