### PR TITLE
Introduce relation schema

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --order random
+--require ./spec/spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
+
 group :test do
   gem 'byebug', platforms: :mri
   gem 'anima', '~> 0.2.0'

--- a/lib/rom/sql/commands/create.rb
+++ b/lib/rom/sql/commands/create.rb
@@ -16,6 +16,20 @@ module ROM
 
         use :associates
 
+        def self.build(relation, options = {})
+          super(relation, options.merge(input: default_input(relation)))
+        end
+
+        def self.default_input(relation)
+          schema = relation.class.schema
+
+          if relation.class.schema
+            Types::Hash.schema(schema)
+          else
+            Hash
+          end
+        end
+
         # Inserts provided tuples into the database table
         #
         # @api public

--- a/lib/rom/sql/commands/create.rb
+++ b/lib/rom/sql/commands/create.rb
@@ -1,6 +1,7 @@
 require 'rom/sql/commands'
 require 'rom/sql/commands/error_wrapper'
 require 'rom/sql/commands/transaction'
+require 'rom/sql/commands/default_input'
 
 module ROM
   module SQL
@@ -11,24 +12,12 @@ module ROM
       class Create < ROM::Commands::Create
         adapter :sql
 
+        extend DefaultInput
+
         include Transaction
         include ErrorWrapper
 
         use :associates
-
-        def self.build(relation, options = {})
-          super(relation, options.merge(input: default_input(relation)))
-        end
-
-        def self.default_input(relation)
-          schema = relation.class.schema
-
-          if relation.class.schema
-            Types::Hash.schema(schema)
-          else
-            Hash
-          end
-        end
 
         # Inserts provided tuples into the database table
         #

--- a/lib/rom/sql/commands/default_input.rb
+++ b/lib/rom/sql/commands/default_input.rb
@@ -1,0 +1,27 @@
+module ROM
+  module SQL
+    module Commands
+      # @api private
+      module DefaultInput
+        # Builds a command and creates a default input handler from a relation
+        # schema
+        #
+        # @api public
+        def build(relation, options = {})
+          super(relation, options.merge(input: default_input(relation)))
+        end
+
+        # @api private
+        def default_input(relation)
+          schema = relation.class.schema
+
+          if relation.class.schema
+            Types::Hash.schema(schema)
+          else
+            Hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/commands/default_input.rb
+++ b/lib/rom/sql/commands/default_input.rb
@@ -8,18 +8,14 @@ module ROM
         #
         # @api public
         def build(relation, options = {})
-          super(relation, options.merge(input: default_input(relation)))
-        end
+          input_processor =
+            if relation.schema?
+              Types::Hash.schema(relation.schema)
+            else
+              input
+            end
 
-        # @api private
-        def default_input(relation)
-          schema = relation.class.schema
-
-          if relation.class.schema
-            Types::Hash.schema(schema)
-          else
-            Hash
-          end
+          super(relation, options.merge(input: input_processor))
         end
       end
     end

--- a/lib/rom/sql/commands/update.rb
+++ b/lib/rom/sql/commands/update.rb
@@ -14,6 +14,7 @@ module ROM
         adapter :sql
 
         extend Deprecations
+        extend DefaultInput
 
         include Transaction
         include ErrorWrapper

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -1,5 +1,6 @@
 require 'rom/sql/header'
 
+require 'rom/sql/schema'
 require 'rom/sql/relation/reading'
 require 'rom/sql/relation/writing'
 
@@ -14,6 +15,8 @@ module ROM
     # Sequel-specific relation extensions
     #
     class Relation < ROM::Relation
+      include SQL
+
       adapter :sql
 
       use :key_inference
@@ -67,6 +70,10 @@ module ROM
       end
 
       primary_key :id
+
+      def self.schema(&block)
+        @schema ||= Schema::DSL.new(&block).call
+      end
 
       # @api private
       def initialize(dataset, registry = {})

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -71,6 +71,25 @@ module ROM
 
       primary_key :id
 
+      # Specify canonical schema for a relation
+      #
+      # With a schema defined commands will set up a type-safe input handler
+      # automatically
+      #
+      # @example
+      #   class Users < ROM::Relation[:sql]
+      #     schema do
+      #       attribute :id, Types::Serial
+      #       attribute :name, Types::String
+      #     end
+      #   end
+      #
+      #   # access schema
+      #   Users.schema
+      #
+      # @return [Schema]
+      #
+      # @api public
       def self.schema(&block)
         if defined?(@schema)
           @schema

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -72,7 +72,11 @@ module ROM
       primary_key :id
 
       def self.schema(&block)
-        @schema ||= Schema::DSL.new(&block).call
+        if defined?(@schema)
+          @schema
+        elsif block
+          @schema = Schema::DSL.new(&block).call
+        end
       end
 
       # @api private

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -122,10 +122,12 @@ module ROM
         dataset.columns
       end
 
+      # @api private
       def schema?
         ! schema.nil?
       end
 
+      # @api private
       def schema
         self.class.schema
       end

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -121,6 +121,14 @@ module ROM
       def columns
         dataset.columns
       end
+
+      def schema?
+        ! schema.nil?
+      end
+
+      def schema
+        self.class.schema
+      end
     end
   end
 end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -6,6 +6,7 @@ module ROM
   module SQL
     class Schema
       include Dry::Equalizer(:attributes)
+      include Enumerable
 
       attr_reader :attributes
 
@@ -29,6 +30,10 @@ module ROM
       def initialize(attributes = {})
         @attributes = attributes
         freeze
+      end
+
+      def each(&block)
+        attributes.each(&block)
       end
     end
   end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -1,0 +1,35 @@
+require 'dry-equalizer'
+
+require 'rom/sql/types'
+
+module ROM
+  module SQL
+    class Schema
+      include Dry::Equalizer(:attributes)
+
+      attr_reader :attributes
+
+      class DSL < BasicObject
+        attr_reader :attributes
+
+        def initialize(&block)
+          @attributes = {}
+          instance_exec(&block)
+        end
+
+        def attribute(name, type)
+          @attributes[name] = type
+        end
+
+        def call
+          Schema.new(attributes)
+        end
+      end
+
+      def initialize(attributes = {})
+        @attributes = attributes
+        freeze
+      end
+    end
+  end
+end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -4,34 +4,51 @@ require 'rom/sql/types'
 
 module ROM
   module SQL
+    # Relation schema
+    #
+    # @api public
     class Schema
       include Dry::Equalizer(:attributes)
       include Enumerable
 
       attr_reader :attributes
 
+      # @api public
       class DSL < BasicObject
         attr_reader :attributes
 
+        # @api private
         def initialize(&block)
           @attributes = {}
           instance_exec(&block)
         end
 
+        # Defines a relation attribute with its type
+        #
+        # @see Relation.schema
+        #
+        # @api public
         def attribute(name, type)
           @attributes[name] = type
         end
 
+        # @api private
         def call
           Schema.new(attributes)
         end
       end
 
+      # @api private
       def initialize(attributes = {})
         @attributes = attributes
         freeze
       end
 
+      # Iterate over schema's attributes
+      #
+      # @yield [Dry::Data::Type]
+      #
+      # @api public
       def each(&block)
         attributes.each(&block)
       end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -8,10 +8,10 @@ module ROM
     #
     # @api public
     class Schema
-      include Dry::Equalizer(:attributes)
+      include Dry::Equalizer(:attributes, :meta)
       include Enumerable
 
-      attr_reader :attributes
+      attr_reader :attributes, :meta
 
       # @api public
       class DSL < BasicObject
@@ -32,6 +32,16 @@ module ROM
           @attributes[name] = type
         end
 
+        # Specify which key(s) should be the primary key
+        #
+        # @api public
+        def primary_key(*names)
+          names.each do |name|
+            attributes[name] = attributes[name].with(primary_key: true)
+          end
+          self
+        end
+
         # @api private
         def call
           Schema.new(attributes)
@@ -39,9 +49,23 @@ module ROM
       end
 
       # @api private
-      def initialize(attributes = {})
+      def initialize(attributes)
         @attributes = attributes
         freeze
+      end
+
+      # Return attribute
+      #
+      # @api public
+      def [](name)
+        attributes.fetch(name)
+      end
+
+      # @api public
+      def primary_key
+        attributes.values.select do |attr|
+          attr.respond_to?(:options) && attr.options[:primary_key] == true
+        end
       end
 
       # Iterate over schema's attributes

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -37,7 +37,7 @@ module ROM
         # @api public
         def primary_key(*names)
           names.each do |name|
-            attributes[name] = attributes[name].with(primary_key: true)
+            attributes[name] = attributes[name].meta(primary_key: true)
           end
           self
         end
@@ -64,7 +64,7 @@ module ROM
       # @api public
       def primary_key
         attributes.values.select do |attr|
-          attr.respond_to?(:options) && attr.options[:primary_key] == true
+          attr.meta[:primary_key] == true
         end
       end
 

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -1,0 +1,12 @@
+require 'dry-data'
+
+module ROM
+  module SQL
+    module Types
+      # FIXME: missing interface in dry-data
+      Dry::Data.define_constants(self, Dry::Data.container._container.keys)
+
+      Serial = Strict::String.constrained(min_size: 1)
+    end
+  end
+end

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -6,7 +6,7 @@ module ROM
       # FIXME: missing interface in dry-data
       Dry::Data.define_constants(self, Dry::Data.container._container.keys)
 
-      Serial = Strict::String.constrained(min_size: 1)
+      Serial = Strict::Int.constrained(gt: 0)
     end
   end
 end

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -1,10 +1,9 @@
-require 'dry-data'
+require 'dry-types'
 
 module ROM
   module SQL
     module Types
-      # FIXME: missing interface in dry-data
-      Dry::Data.define_constants(self, Dry::Data.container._container.keys)
+      include Dry::Types.module
 
       Serial = Strict::Int.constrained(gt: 0)
     end

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -5,7 +5,7 @@ module ROM
     module Types
       include Dry::Types.module
 
-      Serial = Strict::Int.constrained(gt: 0)
+      Serial = Strict::Int.constrained(gt: 0).with(primary_key: true)
     end
   end
 end

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -5,7 +5,7 @@ module ROM
     module Types
       include Dry::Types.module
 
-      Serial = Strict::Int.constrained(gt: 0).with(primary_key: true)
+      Serial = Strict::Int.constrained(gt: 0).meta(primary_key: true)
     end
   end
 end

--- a/lib/rom/sql/types/pg.rb
+++ b/lib/rom/sql/types/pg.rb
@@ -1,0 +1,22 @@
+require 'dry-data'
+require 'sequel'
+
+module ROM
+  module SQL
+    module Types
+      module PG
+        Sequel.extension(:pg_json)
+
+        Array = Dry::Data::Type.new(
+          Sequel.method(:pg_json), primitive: Sequel::Postgres::JSONArray
+        )
+
+        Hash = Dry::Data::Type.new(
+          Sequel.method(:pg_json), primitive: Sequel::Postgres::JSONHash
+        )
+
+        JSON = Array | Hash
+      end
+    end
+  end
+end

--- a/lib/rom/sql/types/pg.rb
+++ b/lib/rom/sql/types/pg.rb
@@ -1,4 +1,4 @@
-require 'dry-data'
+require 'dry-types'
 require 'sequel'
 
 module ROM
@@ -7,13 +7,13 @@ module ROM
       module PG
         Sequel.extension(:pg_json)
 
-        Array = Dry::Data::Type.new(
-          Sequel.method(:pg_json), primitive: Sequel::Postgres::JSONArray
-        )
+        Array = Dry::Types::Definition
+          .new(Sequel::Postgres::JSONArray)
+          .constructor(Sequel.method(:pg_json))
 
-        Hash = Dry::Data::Type.new(
-          Sequel.method(:pg_json), primitive: Sequel::Postgres::JSONHash
-        )
+        Hash = Dry::Types::Definition
+          .new(Sequel::Postgres::JSONHash)
+          .constructor(Sequel.method(:pg_json))
 
         JSON = Array | Hash
       end

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sequel", "~> 4.18"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"
+  spec.add_runtime_dependency "dry-data", "~> 0.5"
   spec.add_runtime_dependency "rom", "~> 1.0.0"
 
   spec.add_development_dependency "bundler"

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sequel", "~> 4.18"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"
-  spec.add_runtime_dependency "dry-data", "~> 0.5"
+  spec.add_runtime_dependency "dry-types", "~> 0.6", "~> 0.6.0"
   spec.add_runtime_dependency "rom", "~> 1.0.0"
 
   spec.add_development_dependency "bundler"

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sequel", "~> 4.18"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"
-  spec.add_runtime_dependency "dry-types", "~> 0.6", "~> 0.6.0"
+  spec.add_runtime_dependency "dry-types", "~> 0.7"
   spec.add_runtime_dependency "rom", "~> 1.0.0"
 
   spec.add_development_dependency "bundler"

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -139,6 +139,29 @@ describe 'Commands / Create' do
     end
   end
 
+  it 'uses relation schema for the default input handler' do
+    configuration.relation(:users) do
+      register_as :users_with_schema
+
+      schema do
+        attribute :id, ROM::SQL::Types::Serial
+        attribute :name, ROM::SQL::Types::String
+      end
+    end
+
+    configuration.commands(:users_with_schema) do
+      define(:create) do
+        result :one
+      end
+    end
+
+    create = container.commands[:users_with_schema][:create]
+
+    expect(create.input[foo: 'bar', id: 1, name: 'Jane']).to eql(
+      id: 1, name: 'Jane'
+    )
+  end
+
   it 'returns a single tuple when result is set to :one' do
     result = users.try { users.create.call(name: 'Jane') }
 

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -6,28 +6,30 @@ describe 'Commands / Update' do
 
   subject(:users) { container.command(:users) }
 
+  let(:update) { container.commands[:users][:update] }
+
   let(:relation) { container.relations.users }
   let(:piotr) { relation.by_name('Piotr').one }
   let(:peter) { { name: 'Peter' } }
 
   context 'with a schema' do
-    it 'uses relation schema for the default input handler' do
+    before do
       configuration.relation(:users) do
         schema do
           attribute :id, ROM::SQL::Types::Serial
           attribute :name, ROM::SQL::Types::String
         end
       end
+    end
 
+    it 'uses relation schema for the default input handler' do
       configuration.commands(:users) do
         define(:update) do
           result :one
         end
       end
 
-      create = container.commands[:users][:update]
-
-      expect(create.input[foo: 'bar', id: 1, name: 'Jane']).to eql(
+      expect(update.input[foo: 'bar', id: 1, name: 'Jane']).to eql(
         id: 1, name: 'Jane'
       )
     end
@@ -59,6 +61,12 @@ describe 'Commands / Update' do
     end
 
     after { Object.send(:remove_const, :User) }
+
+    it 'respects configured input handler' do
+      expect(update.input[foo: 'bar', id: 1, name: 'Jane']).to eql(
+        foo: 'bar', id: 1, name: 'Jane'
+      )
+    end
 
     context '#transaction' do
       it 'update record if there was no errors' do

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -10,82 +10,107 @@ describe 'Commands / Update' do
   let(:piotr) { relation.by_name('Piotr').one }
   let(:peter) { { name: 'Peter' } }
 
-  before do
-    configuration.relation(:users) do
-      def by_id(id)
-        where(id: id).limit(1)
+  context 'with a schema' do
+    it 'uses relation schema for the default input handler' do
+      configuration.relation(:users) do
+        schema do
+          attribute :id, ROM::SQL::Types::Serial
+          attribute :name, ROM::SQL::Types::String
+        end
       end
 
-      def by_name(name)
-        where(name: name)
+      configuration.commands(:users) do
+        define(:update) do
+          result :one
+        end
       end
+
+      create = container.commands[:users][:update]
+
+      expect(create.input[foo: 'bar', id: 1, name: 'Jane']).to eql(
+        id: 1, name: 'Jane'
+      )
     end
-
-    configuration.commands(:users) do
-      define(:update)
-    end
-
-    User = Class.new { include Anima.new(:id, :name) }
-
-    configuration.mappers do
-      register :users, entity: -> tuples { tuples.map { |tuple| User.new(tuple) } }
-    end
-
-    relation.insert(name: 'Piotr')
   end
 
-  after { Object.send(:remove_const, :User) }
+  context 'without a schema' do
+    before do
+      configuration.relation(:users) do
+        def by_id(id)
+          where(id: id).limit(1)
+        end
 
-  context '#transaction' do
-    it 'update record if there was no errors' do
-      result = users.update.transaction do
+        def by_name(name)
+          where(name: name)
+        end
+      end
+
+      configuration.commands(:users) do
+        define(:update)
+      end
+
+      User = Class.new { include Anima.new(:id, :name) }
+
+      configuration.mappers do
+        register :users, entity: -> tuples { tuples.map { |tuple| User.new(tuple) } }
+      end
+
+      relation.insert(name: 'Piotr')
+    end
+
+    after { Object.send(:remove_const, :User) }
+
+    context '#transaction' do
+      it 'update record if there was no errors' do
+        result = users.update.transaction do
+          users.update.by_id(piotr[:id]).call(peter)
+        end
+
+        expect(result.value).to eq([{ id: 1, name: 'Peter' }])
+      end
+
+      it 'updates nothing if error was raised' do
+        users.update.transaction do
+          users.update.by_id(piotr[:id]).call(peter)
+          raise ROM::SQL::Rollback
+        end
+
+        expect(relation.one[:name]).to eql('Piotr')
+      end
+    end
+
+    it 'updates everything when there is no original tuple' do
+      result = users.try do
         users.update.by_id(piotr[:id]).call(peter)
       end
 
-      expect(result.value).to eq([{ id: 1, name: 'Peter' }])
+      expect(result.value.to_a).to match_array([{ id: 1, name: 'Peter' }])
     end
 
-    it 'updates nothing if error was raised' do
-      users.update.transaction do
-        users.update.by_id(piotr[:id]).call(peter)
-        raise ROM::SQL::Rollback
+    it 'updates when attributes changed' do
+      result = users.try do
+        users.as(:entity).update.by_id(piotr[:id]).change(User.new(piotr)).call(peter)
       end
 
-      expect(relation.one[:name]).to eql('Piotr')
-    end
-  end
-
-  it 'updates everything when there is no original tuple' do
-    result = users.try do
-      users.update.by_id(piotr[:id]).call(peter)
+      expect(result.value.to_a).to match_array([User.new(id: 1, name: 'Peter')])
     end
 
-    expect(result.value.to_a).to match_array([{ id: 1, name: 'Peter' }])
-  end
+    it 'does not update when attributes did not change' do
+      result = users.try do
+        command = users.update.by_id(piotr[:id]).change(piotr)
 
-  it 'updates when attributes changed' do
-    result = users.try do
-      users.as(:entity).update.by_id(piotr[:id]).change(User.new(piotr)).call(peter)
+        expect(command.relation).not_to receive(:update)
+
+        command.call(name: piotr[:name])
+      end
+
+      expect(result.value.to_a).to be_empty
     end
 
-    expect(result.value.to_a).to match_array([User.new(id: 1, name: 'Peter')])
-  end
-
-  it 'does not update when attributes did not change' do
-    result = users.try do
-      command = users.update.by_id(piotr[:id]).change(piotr)
-
-      expect(command.relation).not_to receive(:update)
-
-      command.call(name: piotr[:name])
+    it 're-reaises database errors' do
+      expect {
+        users.try { users.update.by_id(piotr[:id]).call(bogus_field: '#trollface') }
+      }.to raise_error(ROM::SQL::DatabaseError, /bogus_field/)
     end
-
-    expect(result.value.to_a).to be_empty
-  end
-
-  it 're-reaises database errors' do
-    expect {
-      users.try { users.update.by_id(piotr[:id]).call(bogus_field: '#trollface') }
-    }.to raise_error(ROM::SQL::DatabaseError, /bogus_field/)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,11 +37,18 @@ RSpec.configure do |config|
   end
 
   config.before do
+    module Test
+      def self.remove_constants
+        constants.each { |const| remove_const(const) }
+        self
+      end
+    end
     @constants = Object.constants
   end
 
   config.after do
     added_constants = Object.constants - @constants
     added_constants.each { |name| Object.send(:remove_const, name) }
+    Object.send(:remove_const, Test.remove_constants.name)
   end
 end

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -16,6 +16,26 @@ describe ROM::Relation do
     configuration.relation(:tasks)
   end
 
+  describe '.schema' do
+    it 'defines a canonical schema for a relation' do
+      class Test::Users < ROM::Relation[:sql]
+        schema do
+          attribute :id, Types::Serial
+          attribute :name, Types::String
+          attribute :admin, Types::Bool
+        end
+      end
+
+      schema = ROM::SQL::Schema.new(
+        id: ROM::SQL::Types::Serial,
+        name: ROM::SQL::Types::String,
+        admin: ROM::SQL::Types::Bool
+      )
+
+      expect(Test::Users.schema).to eql(schema)
+    end
+  end
+
   describe '#dataset' do
     it 'selects all qualified columns and sorts by pk' do
       expect(users.dataset).to eql(

--- a/spec/unit/relation_spec.rb
+++ b/spec/unit/relation_spec.rb
@@ -32,7 +32,24 @@ describe ROM::Relation do
         admin: ROM::SQL::Types::Bool
       )
 
+      expect(Test::Users.schema.primary_key).to eql([Test::Users.schema[:id]])
+
       expect(Test::Users.schema).to eql(schema)
+    end
+
+    it 'allows setting composite primary key' do
+      class Test::Users < ROM::Relation[:sql]
+        schema do
+          attribute :name, Types::String
+          attribute :email, Types::String
+
+          primary_key :name, :email
+        end
+      end
+
+      schema = Test::Users.schema
+
+      expect(schema.primary_key).to eql([schema[:name], schema[:email]])
     end
   end
 

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -1,0 +1,30 @@
+require 'rom/sql/types'
+require 'rom/sql/types/pg'
+
+RSpec.describe ROM::SQL::Types do
+  describe ROM::SQL::Types::Serial do
+    it 'accepts ints > 0' do
+      expect(ROM::SQL::Types::Serial[1]).to be(1)
+    end
+
+    it 'raises when input is <= 0' do
+      expect { ROM::SQL::Types::Serial[0] }.to raise_error(Dry::Data::ConstraintError)
+    end
+  end
+
+  describe ROM::SQL::Types::PG::JSON do
+    it 'coerces to pg json hash' do
+      input = { foo: 'bar' }
+
+      expect(ROM::SQL::Types::PG::JSON[input]).to eql(Sequel.pg_json(input))
+    end
+
+    it 'coerces to pg json array' do
+      input = [1, 2, 3]
+      output = ROM::SQL::Types::PG::JSON[input]
+
+      expect(output).to be_instance_of(Sequel::Postgres::JSONArray)
+      expect(output.to_a).to eql(input)
+    end
+  end
+end

--- a/spec/unit/types_spec.rb
+++ b/spec/unit/types_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ROM::SQL::Types do
     end
 
     it 'raises when input is <= 0' do
-      expect { ROM::SQL::Types::Serial[0] }.to raise_error(Dry::Data::ConstraintError)
+      expect { ROM::SQL::Types::Serial[0] }.to raise_error(Dry::Types::ConstraintError)
     end
   end
 


### PR DESCRIPTION
This adds `schema` DSL to relations:

``` ruby
class Posts < ROM::Relation[:sql]
  schema do
    attribute :id, Types::Serial
    attribute :title, Types::String
    attribute :body, Types::Text
    attribute :tags, Types::Array
  end
end
```

This is awesome because commands can use the schema to create their input handlers:

``` ruby
class CreatePost < ROM::Commands::Create[:sql]
  relation :posts
  register_as :create
  result :one
end

rom.commands[:posts][:create].input # <= dry-data's safe hash
```

Furthermore, we can generate commands automatically in other places, like rom-repository.