### PR TITLE
Use qualified combination keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,13 @@ gemspec
 
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
 gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
-gem 'rom-support', github: 'rom-rb/rom-support', branch: 'call-to_sym'
+gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
 
 group :test do
   gem 'byebug', platforms: :mri
   gem 'anima', '~> 0.2.0'
   gem 'virtus'
-  gem 'activesupport'
+  gem 'activesupport', '~> 4.2'
   gem 'rspec', '~> 3.1'
   gem 'codeclimate-test-reporter', require: false
   gem 'pg', platforms: [:mri, :rbx]

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
-gem 'rom', github: 'rom-rb/rom', branch: 'master'
+gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
 gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
-gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
+gem 'rom', github: 'rom-rb/rom', branch: 'master'
 gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
 gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
-gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
+gem 'rom-support', github: 'rom-rb/rom-support', branch: 'call-to_sym'
 
 group :test do
   gem 'byebug', platforms: :mri

--- a/lib/rom/plugins/relation/sql/auto_combine.rb
+++ b/lib/rom/plugins/relation/sql/auto_combine.rb
@@ -42,7 +42,8 @@ module ROM
 
             # @api private
             def preload(source_key, target_key, source)
-              where(target_key => source.map { |tuple| tuple[source_key] })
+              source_attr = source_key.is_a?(ROM::SQL::QualifiedName) ? source_key.attribute : source_key
+              where(target_key => source.map { |tuple| tuple[source_attr] })
             end
           end
         end

--- a/lib/rom/plugins/relation/sql/auto_combine.rb
+++ b/lib/rom/plugins/relation/sql/auto_combine.rb
@@ -42,8 +42,7 @@ module ROM
 
             # @api private
             def preload(source_key, target_key, source)
-              source_attr = source_key.is_a?(ROM::SQL::QualifiedName) ? source_key.attribute : source_key
-              where(target_key => source.map { |tuple| tuple[source_attr] })
+              where(target_key => source.map { |tuple| tuple[source_key.to_sym] })
             end
           end
         end

--- a/lib/rom/plugins/relation/sql/auto_wrap.rb
+++ b/lib/rom/plugins/relation/sql/auto_wrap.rb
@@ -32,7 +32,7 @@ module ROM
 
               inner_join(name, keys)
                 .select(*qualified.header.columns)
-                .select_append(*other.prefix(other.name).qualified.header)
+                .select_append(*other.prefix(other.name.dataset).qualified.header)
             end
           end
         end

--- a/lib/rom/sql/association.rb
+++ b/lib/rom/sql/association.rb
@@ -1,3 +1,5 @@
+require 'rom/sql/qualified_name'
+
 module ROM
   module SQL
     class Association
@@ -15,10 +17,14 @@ module ROM
       option :result, accepts: [Symbol], reader: true, default: -> assoc { assoc.class.result }
 
       def initialize(source, target, options = {})
-        @source = source
-        @target = options[:relation] || target
-        @name = target
+        @source = Relation::Name[source]
+        @target = Relation::Name[options[:relation] || target, target]
+        @name = self.target.dataset
         super
+      end
+
+      def qualify(name, attribute)
+        QualifiedName.new(name.dataset, attribute)
       end
     end
   end

--- a/lib/rom/sql/association/many_to_many.rb
+++ b/lib/rom/sql/association/many_to_many.rb
@@ -19,9 +19,15 @@ module ROM
           source_key = relations[source.relation].primary_key
           target_key = relations[through.relation].foreign_key(source)
 
+          { source_key => target_key }
+        end
+
+        def join_keys(relations)
+          source_key = relations[source.relation].primary_key
+          target_key = relations[through.relation].foreign_key(source)
+
           { qualify(source, source_key) => qualify(through, target_key) }
         end
-        alias_method :join_keys, :combine_keys
 
         def call(relations)
           left = relations[through.relation].schema.associations[target.dataset].call(relations)

--- a/lib/rom/sql/association/many_to_many.rb
+++ b/lib/rom/sql/association/many_to_many.rb
@@ -16,24 +16,24 @@ module ROM
         end
 
         def combine_keys(relations)
-          source_key = relations[source.relation].primary_key
-          target_key = relations[through.relation].foreign_key(source)
+          source_key = relations[source].primary_key
+          target_key = relations[through].foreign_key(source)
 
           { source_key => target_key }
         end
 
         def join_keys(relations)
-          source_key = relations[source.relation].primary_key
-          target_key = relations[through.relation].foreign_key(source)
+          source_key = relations[source].primary_key
+          target_key = relations[through].foreign_key(source)
 
           { qualify(source, source_key) => qualify(through, target_key) }
         end
 
         def call(relations)
-          left = relations[through.relation].schema.associations[target.dataset].call(relations)
-          right = relations[target.relation]
+          left = relations[through].schema.associations[target.dataset].call(relations)
+          right = relations[target]
 
-          left_fk = relations[through.relation].foreign_key(source)
+          left_fk = relations[through].foreign_key(source)
           columns = right.header.qualified.to_a + [left_fk]
 
           relation = left

--- a/lib/rom/sql/association/many_to_one.rb
+++ b/lib/rom/sql/association/many_to_one.rb
@@ -5,22 +5,22 @@ module ROM
         result :one
 
         def combine_keys(relations)
-          source_key = relations[target.relation].primary_key
-          target_key = relations[source.relation].foreign_key(target)
+          source_key = relations[target].primary_key
+          target_key = relations[source].foreign_key(target)
 
           { source_key => target_key }
         end
 
         def join_keys(relations)
-          source_key = relations[target.relation].primary_key
-          target_key = relations[source.relation].foreign_key(target)
+          source_key = relations[target].primary_key
+          target_key = relations[source].foreign_key(target)
 
           { qualify(target, source_key) => qualify(source, target_key) }
         end
 
         def call(relations)
-          left = relations[target.relation]
-          right = relations[source.relation]
+          left = relations[target]
+          right = relations[source]
 
           right_pk = right.schema.primary_key.map { |a| a.meta[:name] }
           right_fk = right.foreign_key(target)

--- a/lib/rom/sql/association/many_to_one.rb
+++ b/lib/rom/sql/association/many_to_one.rb
@@ -6,9 +6,9 @@ module ROM
 
         def combine_keys(relations)
           source_key = relations[target.relation].primary_key
-          target_key = relations[target.relation].foreign_key(source)
+          target_key = relations[source.relation].foreign_key(target)
 
-          { qualify(target, source_key) => qualify(target, target_key) }
+          { source_key => target_key }
         end
 
         def join_keys(relations)

--- a/lib/rom/sql/association/many_to_one.rb
+++ b/lib/rom/sql/association/many_to_one.rb
@@ -5,22 +5,22 @@ module ROM
         result :one
 
         def combine_keys(relations)
-          source_key = relations[target].primary_key
-          target_key = relations[target].foreign_key(source)
+          source_key = relations[target.relation].primary_key
+          target_key = relations[target.relation].foreign_key(source)
 
-          { source_key => target_key }
+          { qualify(target, source_key) => qualify(target, target_key) }
         end
 
         def join_keys(relations)
-          source_key = relations[target].primary_key
-          target_key = relations[source].foreign_key(target)
+          source_key = relations[target.relation].primary_key
+          target_key = relations[source.relation].foreign_key(target)
 
-          { source_key => target_key }
+          { qualify(target, source_key) => qualify(source, target_key) }
         end
 
         def call(relations)
-          left = relations[target]
-          right = relations[source]
+          left = relations[target.relation]
+          right = relations[source.relation]
 
           right_pk = right.schema.primary_key.map { |a| a.meta[:name] }
           right_fk = right.foreign_key(target)
@@ -30,7 +30,7 @@ module ROM
           columns = left.header.qualified.to_a + right.header.project(*right_pk).rename(pk_to_fk).qualified.to_a
 
           relation = left
-            .inner_join(source, right_fk => left.primary_key)
+            .inner_join(source.dataset, right_fk => left.primary_key)
             .select(*columns)
             .order(*right.header.project(*right.primary_key).qualified)
 

--- a/lib/rom/sql/association/one_to_one.rb
+++ b/lib/rom/sql/association/one_to_one.rb
@@ -8,9 +8,15 @@ module ROM
           source_key = relations[source.relation].primary_key
           target_key = relations[target.relation].foreign_key(source)
 
+          { source_key => target_key }
+        end
+
+        def join_keys(relations)
+          source_key = relations[source.relation].primary_key
+          target_key = relations[target.relation].foreign_key(source)
+
           { qualify(source, source_key) => qualify(target, target_key) }
         end
-        alias_method :join_keys, :combine_keys
 
         def call(relations)
           left = relations[source.relation]

--- a/lib/rom/sql/association/one_to_one.rb
+++ b/lib/rom/sql/association/one_to_one.rb
@@ -5,16 +5,16 @@ module ROM
         result :one
 
         def combine_keys(relations)
-          source_key = relations[source].primary_key
-          target_key = relations[target].foreign_key(source)
+          source_key = relations[source.relation].primary_key
+          target_key = relations[target.relation].foreign_key(source)
 
-          { source_key => target_key }
+          { qualify(source, source_key) => qualify(target, target_key) }
         end
         alias_method :join_keys, :combine_keys
 
         def call(relations)
-          left = relations[source]
-          right = relations[target]
+          left = relations[source.relation]
+          right = relations[target.relation]
 
           left_pk = left.primary_key
           right_fk = right.foreign_key(source)
@@ -22,7 +22,7 @@ module ROM
           columns = right.header.qualified.to_a
 
           relation = right
-            .inner_join(source, left_pk => right_fk)
+            .inner_join(source.dataset, left_pk => right_fk)
             .select(*columns)
             .order(*right.header.project(*right.primary_key).qualified)
 

--- a/lib/rom/sql/association/one_to_one.rb
+++ b/lib/rom/sql/association/one_to_one.rb
@@ -5,22 +5,22 @@ module ROM
         result :one
 
         def combine_keys(relations)
-          source_key = relations[source.relation].primary_key
-          target_key = relations[target.relation].foreign_key(source)
+          source_key = relations[source].primary_key
+          target_key = relations[target].foreign_key(source)
 
           { source_key => target_key }
         end
 
         def join_keys(relations)
-          source_key = relations[source.relation].primary_key
-          target_key = relations[target.relation].foreign_key(source)
+          source_key = relations[source].primary_key
+          target_key = relations[target].foreign_key(source)
 
           { qualify(source, source_key) => qualify(target, target_key) }
         end
 
         def call(relations)
-          left = relations[source.relation]
-          right = relations[target.relation]
+          left = relations[source]
+          right = relations[target]
 
           left_pk = left.primary_key
           right_fk = right.foreign_key(source)

--- a/lib/rom/sql/plugin/assoc_macros.rb
+++ b/lib/rom/sql/plugin/assoc_macros.rb
@@ -66,7 +66,7 @@ module ROM
           if assoc.nil?
             raise NoAssociationError,
               "Association #{assoc_name.inspect} has not been " \
-              "defined for relation #{name.inspect}"
+              "defined for relation #{name.relation.inspect}"
           end
 
           type = assoc[:type]
@@ -103,7 +103,7 @@ module ROM
           l_graph = graph(
             assoc[:join_table],
             { assoc[:left_key] => primary_key },
-            select: l_select, implicit_qualifier: self.name
+            select: l_select, implicit_qualifier: self.name.dataset
           )
 
           l_graph.graph(
@@ -124,7 +124,7 @@ module ROM
 
           graph(
             name, join_keys,
-            options.merge(join_type: join_type, implicit_qualifier: self.name)
+            options.merge(join_type: join_type, implicit_qualifier: self.name.dataset)
           )
         end
       end

--- a/lib/rom/sql/qualified_name.rb
+++ b/lib/rom/sql/qualified_name.rb
@@ -1,0 +1,20 @@
+module ROM
+  module SQL
+    class QualifiedName
+      include Dry::Equalizer(:dataset, :attribute)
+
+      attr_reader :dataset
+
+      attr_reader :attribute
+
+      def initialize(dataset, attribute)
+        @dataset = dataset
+        @attribute = attribute
+      end
+
+      def sql_literal_append(ds, sql)
+        ds.qualified_identifier_sql_append(sql, dataset, attribute)
+      end
+    end
+  end
+end

--- a/lib/rom/sql/qualified_name.rb
+++ b/lib/rom/sql/qualified_name.rb
@@ -1,19 +1,43 @@
 module ROM
   module SQL
+    # Used as a pair table name + field name.
+    # Similar to Sequel::SQL::QualifiedIdentifier but we don't want
+    # Sequel types to leak into ROM
+    #
+    # @api private
     class QualifiedName
       include Dry::Equalizer(:dataset, :attribute)
 
+      # Dataset (table) name
+      #
+      # @api private
       attr_reader :dataset
 
+      # Attribute (field, column) name
+      #
+      # @api private
       attr_reader :attribute
 
+      # @api private
       def initialize(dataset, attribute)
         @dataset = dataset
         @attribute = attribute
       end
 
+      # Used by Sequel for building SQL statements
+      #
+      # @api private
       def sql_literal_append(ds, sql)
         ds.qualified_identifier_sql_append(sql, dataset, attribute)
+      end
+
+      # Convinient interface for attribute names
+      #
+      # @return [Symbol]
+      #
+      # @api private
+      def to_sym
+        attribute
       end
     end
   end

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sequel", "~> 4.18"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"
-  spec.add_runtime_dependency "dry-types", "~> 0.7"
+  spec.add_runtime_dependency "dry-types", "~> 0.8"
   spec.add_runtime_dependency "rom", "~> 2.0"
 
   spec.add_development_dependency "bundler"

--- a/spec/integration/association/many_to_many_spec.rb
+++ b/spec/integration/association/many_to_many_spec.rb
@@ -58,7 +58,13 @@ RSpec.describe ROM::SQL::Association::ManyToMany do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(
+          expect(assoc.combine_keys(container.relations)).to eql(id: :task_id)
+        end
+      end
+
+      describe '#join_keys' do
+        it 'returns key-map used for joins' do
+          expect(assoc.join_keys(container.relations)).to eql(
             ROM::SQL::QualifiedName.new(:tasks, :id) => ROM::SQL::QualifiedName.new(:task_tags, :task_id)
           )
         end

--- a/spec/integration/association/many_to_many_spec.rb
+++ b/spec/integration/association/many_to_many_spec.rb
@@ -58,7 +58,9 @@ RSpec.describe ROM::SQL::Association::ManyToMany do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(id: :task_id)
+          expect(assoc.combine_keys(container.relations)).to eql(
+            ROM::SQL::QualifiedName.new(:tasks, :id) => ROM::SQL::QualifiedName.new(:task_tags, :task_id)
+          )
         end
       end
 

--- a/spec/integration/association/many_to_one_spec.rb
+++ b/spec/integration/association/many_to_one_spec.rb
@@ -54,9 +54,7 @@ RSpec.describe ROM::SQL::Association::ManyToOne do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(
-            ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:users, :task_id)
-          )
+          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
         end
       end
 

--- a/spec/integration/association/many_to_one_spec.rb
+++ b/spec/integration/association/many_to_one_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe ROM::SQL::Association::ManyToOne do
       end
 
       describe '#target' do
-        it 'uses custom relation name' do
+        it 'builds full relation name' do
           assoc = ROM::SQL::Association::ManyToOne.new(:users, :tasks, relation: :foo)
 
           expect(assoc.name).to be(:tasks)
-          expect(assoc.target).to be(:foo)
+          expect(assoc.target).to eql(ROM::Relation::Name[:foo, :tasks])
         end
       end
 
@@ -54,13 +54,17 @@ RSpec.describe ROM::SQL::Association::ManyToOne do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(id: :task_id)
+          expect(assoc.combine_keys(container.relations)).to eql(
+            ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:users, :task_id)
+          )
         end
       end
 
       describe '#join_keys' do
         it 'returns key-map used for joins' do
-          expect(assoc.join_keys(container.relations)).to eql(id: :user_id)
+          expect(assoc.join_keys(container.relations)).to eql(
+            ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:tasks, :user_id)
+          )
         end
       end
 

--- a/spec/integration/association/one_to_many_spec.rb
+++ b/spec/integration/association/one_to_many_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe ROM::SQL::Association::OneToMany do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
+          expect(assoc.combine_keys(container.relations)).to eql(
+            ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:tasks, :user_id)
+          )
         end
       end
 

--- a/spec/integration/association/one_to_many_spec.rb
+++ b/spec/integration/association/one_to_many_spec.rb
@@ -40,7 +40,13 @@ RSpec.describe ROM::SQL::Association::OneToMany do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(
+          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
+        end
+      end
+
+      describe '#join_keys' do
+        it 'returns key-map used for joins' do
+          expect(assoc.join_keys(container.relations)).to eql(
             ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:tasks, :user_id)
           )
         end

--- a/spec/integration/association/one_to_one_spec.rb
+++ b/spec/integration/association/one_to_one_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe ROM::SQL::Association::OneToOne do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
+          expect(assoc.combine_keys(container.relations)).to eql(
+            ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:accounts, :user_id)
+          )
         end
       end
 

--- a/spec/integration/association/one_to_one_spec.rb
+++ b/spec/integration/association/one_to_one_spec.rb
@@ -47,7 +47,13 @@ RSpec.describe ROM::SQL::Association::OneToOne do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(
+          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
+        end
+      end
+
+      describe '#join_keys' do
+        it 'returns key-map used for joins' do
+          expect(assoc.join_keys(container.relations)).to eql(
             ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:accounts, :user_id)
           )
         end

--- a/spec/integration/association/one_to_one_through_spec.rb
+++ b/spec/integration/association/one_to_one_through_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe ROM::SQL::Association::OneToOneThrough do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
+          expect(assoc.combine_keys(container.relations)).to eql(
+            ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:accounts, :user_id)
+          )
         end
       end
 

--- a/spec/integration/association/one_to_one_through_spec.rb
+++ b/spec/integration/association/one_to_one_through_spec.rb
@@ -69,7 +69,13 @@ RSpec.describe ROM::SQL::Association::OneToOneThrough do
 
       describe '#combine_keys' do
         it 'returns key-map used for in-memory tuple-combining' do
-          expect(assoc.combine_keys(container.relations)).to eql(
+          expect(assoc.combine_keys(container.relations)).to eql(id: :user_id)
+        end
+      end
+
+      describe '#join_keys' do
+        it 'returns key-map used for joins' do
+          expect(assoc.join_keys(container.relations)).to eql(
             ROM::SQL::QualifiedName.new(:users, :id) => ROM::SQL::QualifiedName.new(:accounts, :user_id)
           )
         end


### PR DESCRIPTION
This leverages new relation name object (https://github.com/rom-rb/rom/pull/347) and also adds qualified identifiers for associations. Now it is possible to use associations when your PK/FK do not follow common naming conventions. I.e. something like `tenants.tenant_id (PK) <= users.tenant_id (FK)` should work fine.

This PR also contains a breaking change for ad hoc combination names in associations (this won't work anymore: https://github.com/rom-rb/rom-repository/blob/master/spec/shared/relations.rb#L58). Now when you write `belongs :sutin` `sutin` means a dataset (table) name, not a relation name. You can add a relation name with `belongs :weird_name, relation: :nice_name`. This should remove the confusion described in https://github.com/rom-rb/rom-sql/issues/67 We add a combination name later quite easily with a more verbose syntax eg `belongs :users, relation: :authors, as: :author`.

Current state: not ready, there are still some issues with combining. I also plan to add a bunch of specs for weird naming, this will guarantee support for legacy DB schemas.