### PR TITLE
Refactor :associates plugin to use Association API

### DIFF
--- a/lib/rom/sql/association.rb
+++ b/lib/rom/sql/association.rb
@@ -24,6 +24,10 @@ module ROM
         super
       end
 
+      def join_key_map(relations)
+        join_keys(relations).to_a.flatten.map(&:to_sym)
+      end
+
       def qualify(name, attribute)
         QualifiedName.new(name.dataset, attribute)
       end

--- a/lib/rom/sql/association/many_to_many.rb
+++ b/lib/rom/sql/association/many_to_many.rb
@@ -15,13 +15,25 @@ module ROM
                                         options[:through])
         end
 
+        def associate(relations, children, parent)
+          children.map do |tuple|
+            source, target = join_key_map(relations)
+            spk, sfk = source
+            tfk, tpk = target
+            { sfk => tuple.fetch(spk), tfk => parent.fetch(tpk) }
+          end
+        end
+
+        def join_relation(relations)
+          relations[through]
+        end
+
         def join_key_map(relations)
-          join_relation = relations[through]
-
           left = super
-          right = join_relation.schema.associations[target.dataset].join_key_map(relations)
+          right = join_relation(relations)
+            .schema.associations[target.dataset].join_key_map(relations)
 
-          { join_relation => [left, right] }
+          [left, right]
         end
 
         def combine_keys(relations)

--- a/lib/rom/sql/association/many_to_many.rb
+++ b/lib/rom/sql/association/many_to_many.rb
@@ -16,12 +16,11 @@ module ROM
         end
 
         def associate(relations, children, parent)
-          children.map do |tuple|
-            source, target = join_key_map(relations)
-            spk, sfk = source
-            tfk, tpk = target
+          ((spk, sfk), (tfk, tpk)) = join_key_map(relations)
+
+          children.map { |tuple|
             { sfk => tuple.fetch(spk), tfk => parent.fetch(tpk) }
-          end
+          }
         end
 
         def join_relation(relations)

--- a/lib/rom/sql/association/many_to_many.rb
+++ b/lib/rom/sql/association/many_to_many.rb
@@ -15,6 +15,15 @@ module ROM
                                         options[:through])
         end
 
+        def join_key_map(relations)
+          join_relation = relations[through]
+
+          left = super
+          right = join_relation.schema.associations[target.dataset].join_key_map(relations)
+
+          { join_relation => [left, right] }
+        end
+
         def combine_keys(relations)
           source_key = relations[source].primary_key
           target_key = relations[through].foreign_key(source)

--- a/lib/rom/sql/association/many_to_one.rb
+++ b/lib/rom/sql/association/many_to_one.rb
@@ -4,6 +4,11 @@ module ROM
       class ManyToOne < Association
         result :one
 
+        def associate(relations, child, parent)
+          fk, pk = join_key_map(relations)
+          child.merge(fk => parent.fetch(pk))
+        end
+
         def combine_keys(relations)
           source_key = relations[source].foreign_key(target)
           target_key = relations[target].primary_key

--- a/lib/rom/sql/plugin/associates.rb
+++ b/lib/rom/sql/plugin/associates.rb
@@ -1,3 +1,5 @@
+require 'rom/support/deprecations'
+
 module ROM
   module SQL
     module Plugin
@@ -98,6 +100,14 @@ module ROM
             if associations.map(&:first).include?(name)
               raise ArgumentError,
                 "#{name} association is already defined for #{self.class}"
+            end
+
+            if options.any?
+              Deprecations.warn(
+                "Passing options to `associates` is deprecated. " \
+                "Define an association in schema for your :#{relation} relation " \
+                "instead and pass in its name to `associates`"
+              )
             end
 
             option :association, reader: true, default: {}

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -3,6 +3,7 @@ shared_context 'database setup' do
   let(:conn) { Sequel.connect(uri) }
   let(:configuration) { ROM::Configuration.new(:sql, conn) }
   let(:container) { ROM.container(configuration) }
+  let(:relations) { container.relations }
 
   def drop_tables
     %i(task_tags tasks tags

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,9 @@ TMP_PATH = root.join('../tmp')
 
 Dir[root.join('shared/*.rb').to_s].each { |f| require f }
 
+require 'rom/support/deprecations'
+ROM::Deprecations.set_logger!(root.join('../log/deprecations.log'))
+
 RSpec.configure do |config|
   config.before(:suite) do
     tmp_test_dir = TMP_PATH.join('test')


### PR DESCRIPTION
This makes `associates` plugin use defined schema associations and delegate setting FKs. As a bonus commands now support many-to-many where join-tuples are automatically inserted for you.

Passing ad-hoc key options to `associates` macro is now deprecated.