### PR TITLE
One To One and One To Many #associate

### DIFF
--- a/lib/rom/sql/association/one_to_one.rb
+++ b/lib/rom/sql/association/one_to_one.rb
@@ -31,6 +31,12 @@ module ROM
           }
         end
 
+        # @api private
+        def associate(relations, child, parent)
+          pk, fk = join_key_map(relations)
+          child.merge(fk => parent.fetch(pk))
+        end
+
         protected
 
         # @api private

--- a/spec/unit/association/one_to_many_spec.rb
+++ b/spec/unit/association/one_to_many_spec.rb
@@ -8,6 +8,26 @@ RSpec.describe ROM::SQL::Association::OneToMany, helpers: true do
   let(:users) { double(:users, primary_key: :id) }
   let(:tasks) { double(:tasks) }
 
+  describe '#associate' do
+    let(:source) { :users }
+    let(:target) { :tasks }
+
+    let(:relations) do
+      { users: users, tasks: tasks }
+    end
+
+    it 'returns child tuple with FK set' do
+      expect(tasks).to receive(:foreign_key).with(:users).and_return(:user_id)
+
+      task_tuple = { title: 'Task' }
+      user_tuple = { id: 3 }
+
+      expect(assoc.associate(relations, task_tuple, user_tuple)).to eql(
+        user_id: 3, title: 'Task'
+      )
+    end
+  end
+
   shared_examples_for 'one-to-many association' do
     describe '#combine_keys' do
       it 'returns a hash with combine keys' do

--- a/spec/unit/association/one_to_one_spec.rb
+++ b/spec/unit/association/one_to_one_spec.rb
@@ -5,8 +5,29 @@ RSpec.describe ROM::SQL::Association::OneToOne, helpers: true do
 
   let(:options) { {} }
 
-  let(:users) { double(:users, primary_key: :id) }
-  let(:tasks) { double(:tasks) }
+  let(:users)   { double(:users, primary_key: :id) }
+  let(:tasks)   { double(:tasks) }
+  let(:avatars) { double(:avatars) }
+
+  describe '#associate' do
+    let(:source) { :users }
+    let(:target) { :avatar }
+
+    let(:relations) do
+      { users: users, avatar: avatars }
+    end
+
+    it 'returns child tuple with FK set' do
+      expect(avatars).to receive(:foreign_key).with(:users).and_return(:user_id)
+
+      avatar_tuple = { url: 'http://rom-rb.org/images/logo.svg' }
+      user_tuple   = { id: 3 }
+
+      expect(assoc.associate(relations, avatar_tuple, user_tuple)).to eql(
+        user_id: 3, url: 'http://rom-rb.org/images/logo.svg'
+      )
+    end
+  end
 
   shared_examples_for 'one-to-one association' do
     describe '#combine_keys' do


### PR DESCRIPTION
<img width="705" alt="screen shot 2016-08-19 at 09 45 03" src="https://cloud.githubusercontent.com/assets/5089/17802634/a86519da-65f1-11e6-94f5-9d8122904a81.png">

Here's the feature 😉 . This is useful for `hanami-model` integration. 💚 