### PR TITLE
Safe error wrapper

### DIFF
--- a/lib/rom/sql/commands/error_wrapper.rb
+++ b/lib/rom/sql/commands/error_wrapper.rb
@@ -11,7 +11,7 @@ module ROM
         def call(*args)
           super
         rescue *ERROR_MAP.keys => e
-          raise ERROR_MAP[e.class], e
+          raise ERROR_MAP.fetch(e.class, Error), e
         end
 
         alias_method :[], :call

--- a/lib/rom/sql/errors.rb
+++ b/lib/rom/sql/errors.rb
@@ -14,6 +14,7 @@ module ROM
 
     ERROR_MAP = {
       Sequel::DatabaseError => DatabaseError,
+      Sequel::ConstraintViolation => ConstraintError,
       Sequel::NotNullConstraintViolation => NotNullConstraintError,
       Sequel::UniqueConstraintViolation => UniqueConstraintError,
       Sequel::ForeignKeyConstraintViolation => ForeignKeyConstraintError,

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -296,6 +296,14 @@ RSpec.describe 'Commands / Create', :postgres do
         }
       }.to raise_error(ROM::SQL::CheckConstraintError, /name/)
     end
+
+    it 're-raises constraint violation error' do
+      expect {
+        users.try {
+          tasks.create.call(title: '')
+        }
+      }.to raise_error(ROM::SQL::ConstraintError, /title/)
+    end
   end
 
   describe '#upsert' do

--- a/spec/shared/database_setup.rb
+++ b/spec/shared/database_setup.rb
@@ -45,6 +45,8 @@ shared_context 'database setup' do
       primary_key :id
       foreign_key :user_id, :users
       String :title, unique: true
+      constraint(:title_length) { char_length(title) > 1 } if ctx.postgres?(example)
+      constraint(:title_length) { length(title) > 1 }      if ctx.sqlite?(example)
     end
 
     conn.create_table :tags do


### PR DESCRIPTION
This PR aims to fix two issues:
1. [Sometimes](https://travis-ci.org/hanami/model/jobs/158778577) Sequel raises a `Sequel::ConstraintViolation`, when a database constraint is violated. I can't reproduce this locally (Mac OS), but it happens on CI and in general on Linux.
2. `ROM::Sql::Commands::ErrorWrapper` uses internally `ERROR_MAP` with `#[]`. This is dangerous because in case of non-mapped errors, instead of raising a generic error it raises `nil`, which causes a `TypeError`. I changed it with `#fetch` which falls back to the generic error (`ROM::Sql::Error`).
