### PR TITLE
Make OneToOne inherit from OneToMany.

### DIFF
--- a/lib/rom/sql/association.rb
+++ b/lib/rom/sql/association.rb
@@ -68,8 +68,8 @@ module ROM
   end
 end
 
-require 'rom/sql/association/one_to_one'
 require 'rom/sql/association/one_to_many'
+require 'rom/sql/association/one_to_one'
 require 'rom/sql/association/many_to_many'
 require 'rom/sql/association/many_to_one'
 require 'rom/sql/association/one_to_one_through'

--- a/lib/rom/sql/association/one_to_many.rb
+++ b/lib/rom/sql/association/one_to_many.rb
@@ -1,8 +1,51 @@
 module ROM
   module SQL
     class Association
-      class OneToMany < OneToOne
+      class OneToMany < Association
         result :many
+
+        # @api public
+        def call(relations)
+          with_keys(relations) do |left_pk, right_fk|
+            right = relations[target.relation]
+            columns = right.header.qualified.to_a
+
+            relation = right
+              .inner_join(source, left_pk => right_fk)
+              .select(*columns)
+              .order(*right.header.project(*right.primary_key).qualified)
+
+            relation.with(attributes: relation.header.names)
+          end
+        end
+
+        # @api public
+        def combine_keys(relations)
+          Hash[*with_keys(relations)]
+        end
+
+        # @api public
+        def join_keys(relations)
+          with_keys(relations) { |source_key, target_key|
+            { qualify(source, source_key) => qualify(target, target_key) }
+          }
+        end
+
+        # @api private
+        def associate(relations, child, parent)
+          pk, fk = join_key_map(relations)
+          child.merge(fk => parent.fetch(pk))
+        end
+
+        protected
+
+        # @api private
+        def with_keys(relations, &block)
+          source_key = relations[source.relation].primary_key
+          target_key = relations[target.relation].foreign_key(source.relation)
+          return [source_key, target_key] unless block
+          yield(source_key, target_key)
+        end
       end
     end
   end

--- a/lib/rom/sql/association/one_to_one.rb
+++ b/lib/rom/sql/association/one_to_one.rb
@@ -1,51 +1,8 @@
 module ROM
   module SQL
     class Association
-      class OneToOne < Association
+      class OneToOne < OneToMany
         result :one
-
-        # @api public
-        def call(relations)
-          with_keys(relations) do |left_pk, right_fk|
-            right = relations[target.relation]
-            columns = right.header.qualified.to_a
-
-            relation = right
-              .inner_join(source, left_pk => right_fk)
-              .select(*columns)
-              .order(*right.header.project(*right.primary_key).qualified)
-
-            relation.with(attributes: relation.header.names)
-          end
-        end
-
-        # @api public
-        def combine_keys(relations)
-          Hash[*with_keys(relations)]
-        end
-
-        # @api public
-        def join_keys(relations)
-          with_keys(relations) { |source_key, target_key|
-            { qualify(source, source_key) => qualify(target, target_key) }
-          }
-        end
-
-        # @api private
-        def associate(relations, child, parent)
-          pk, fk = join_key_map(relations)
-          child.merge(fk => parent.fetch(pk))
-        end
-
-        protected
-
-        # @api private
-        def with_keys(relations, &block)
-          source_key = relations[source.relation].primary_key
-          target_key = relations[target.relation].foreign_key(source.relation)
-          return [source_key, target_key] unless block
-          yield(source_key, target_key)
-        end
       end
     end
   end


### PR DESCRIPTION
Previously, the `OneToMany` association was inheriting from the `OneToOne`. This is mainly a cosmetic change.