### PR TITLE
Add support for enum DB type

### DIFF
--- a/lib/rom/sql/schema/inferrer.rb
+++ b/lib/rom/sql/schema/inferrer.rb
@@ -15,7 +15,8 @@ module ROM
           boolean: Types::Bool,
           decimal: Types::Decimal,
           float: Types::Float,
-          blob: Types::Blob
+          blob: Types::Blob,
+          enum: Types::String
         ).freeze
 
         numeric_pk_type Types::Serial

--- a/spec/integration/schema_inference_spec.rb
+++ b/spec/integration/schema_inference_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'Schema inference for common datatypes' do
             Boolean :flag, null: false
             Date :date
             DateTime :datetime, null: false
+            String :enum
 
             if ctx.postgres?(example)
               Bytea :data
@@ -71,7 +72,8 @@ RSpec.describe 'Schema inference for common datatypes' do
             flag: ROM::SQL::Types::Bool.meta(name: :flag),
             date: ROM::SQL::Types::Date.optional.meta(name: :date),
             datetime: ROM::SQL::Types::Time.meta(name: :datetime),
-            data: ROM::SQL::Types::Blob.optional.meta(name: :data)
+            data: ROM::SQL::Types::Blob.optional.meta(name: :data),
+            enum: ROM::SQL::Types::String.optional.meta(name: :enum)
           )
         end
       end


### PR DESCRIPTION
I'm using native db `enum` type in my app and was having this error:

`ROM::SQL::UnknownDBTypeError: Cannot find corresponding type for enum`

This solved my problem. Please suggest if there should be any changes.
