### PR TITLE
Expose schema attributes in restriction blocks

### DIFF
--- a/lib/rom/sql/expression.rb
+++ b/lib/rom/sql/expression.rb
@@ -1,0 +1,26 @@
+module ROM
+  module SQL
+    class Expression
+      attr_reader :expr, :type
+
+      def initialize(type, expr = ::Sequel.expr(type.to_sym))
+        @type = type
+        @expr = expr
+      end
+
+      def sql_literal(ds)
+        expr.sql_literal(ds)
+      end
+
+      private
+
+      def method_missing(meth, *args, &block)
+        if type.respond_to?(meth)
+          self.class.new(type.__send__(meth, *args, &block))
+        else
+          self.class.new(type, expr.__send__(meth, *args, &block))
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -1,16 +1,12 @@
 module ROM
   module SQL
     class Function < ROM::Schema::Type
-      def as(aliaz)
-        aliased(aliaz)
+      def as(name)
+        meta(name: name)
       end
 
       def sql_literal_append(ds, sql)
-        if aliased?
-          ds.literal_append(sql, func.as(meta[:alias]))
-        else
-          ds.literal_append(sql, func)
-        end
+        ds.literal_append(sql, func.as(name))
       end
 
       if RUBY_VERSION < '2.3'
@@ -22,11 +18,11 @@ module ROM
       private
 
       def func
-        Sequel::SQL::Function.new(name, *meta[:args])
+        Sequel::SQL::Function.new(meta[:op], *meta[:args])
       end
 
-      def method_missing(name, *args)
-        meta(name: name, args: args)
+      def method_missing(op, *args)
+        meta(op: op, args: args)
       end
     end
 

--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -290,7 +290,11 @@ module ROM
         #
         # @api public
         def where(*args, &block)
-          new(dataset.__send__(__method__, *args, &block))
+          if block
+            new(dataset.where(*args).where(schema.restriction(&block)))
+          else
+            new(dataset.__send__(__method__, *args))
+          end
         end
 
         # Restrict a relation to not match criteria
@@ -322,7 +326,11 @@ module ROM
         #
         # @api public
         def having(*args, &block)
-          new(dataset.__send__(__method__, *args, &block))
+          if block
+            new(dataset.having(*args).having(schema.restriction(&block)))
+          else
+            new(dataset.__send__(__method__, *args, &block))
+          end
         end
 
         # Inverts the current WHERE and HAVING clauses. If there is neither a

--- a/lib/rom/sql/restriction_dsl.rb
+++ b/lib/rom/sql/restriction_dsl.rb
@@ -1,0 +1,28 @@
+require 'rom/sql/expression'
+
+module ROM
+  module SQL
+    class RestrictionDSL < BasicObject
+      attr_reader :schema, :vr
+
+      def initialize(schema)
+        @schema = schema
+        @vr = ::Sequel::VIRTUAL_ROW
+      end
+
+      def call(&block)
+        instance_exec(&block)
+      end
+
+      private
+
+      def method_missing(meth, *args, &block)
+        if schema.key?(meth)
+          ::ROM::SQL::Expression.new(schema[meth])
+        else
+          vr.__send__(meth, *args, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -1,5 +1,6 @@
 require 'rom/schema'
 require 'rom/sql/projection_dsl'
+require 'rom/sql/restriction_dsl'
 
 module ROM
   module SQL
@@ -17,6 +18,11 @@ module ROM
       def initialize(*)
         super
         initialize_primary_key_names
+      end
+
+      # @api public
+      def restriction(&block)
+        RestrictionDSL.new(self).call(&block)
       end
 
       # Return a new schema with attributes marked as qualified

--- a/spec/unit/relation/having_spec.rb
+++ b/spec/unit/relation/having_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ROM::Relation, '#having' do
   subject(:relation) do
-    container.relations.users
+    relations[:users]
       .inner_join(:tasks, user_id: :id)
       .qualified
       .select_group(:id, :name)
@@ -15,7 +15,8 @@ RSpec.describe ROM::Relation, '#having' do
     end
 
     it 'restricts a relation using HAVING clause' do
-      expect(relation.having { count(:tasks__id) >= 2 }.to_a).to eq([{ id: 2, name: 'Joe', task_count: 2 }])
+      expect(relation.having { count(id.qualified) >= 2 }.to_a).
+        to eq([{ id: 2, name: 'Joe', task_count: 2 }])
     end
   end
 end

--- a/spec/unit/relation/select_append_spec.rb
+++ b/spec/unit/relation/select_append_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe ROM::Relation, '#select_append' do
     it 'supports blocks' do
       selected = relation.select(:id).select_append { string::upper(title).as(:title) }
 
-      expect(selected.schema.map(&:name)).to eql(%i[id upper])
-      expect(selected.schema[:upper].alias).to be(:title)
+      expect(selected.schema.map(&:name)).to eql(%i[id title])
       expect(selected.first).to eql(id: 1, title: "JOE'S TASK")
     end
   end

--- a/spec/unit/relation/where_spec.rb
+++ b/spec/unit/relation/where_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe ROM::Relation, '#where' do
+  subject(:relation) { relations[:tasks].select(:id, :title) }
+
+  include_context 'users and tasks'
+
+  before do
+    conf.relation(:tasks) { schema(infer: true) }
+  end
+
+  with_adapters do
+    it 'restricts relation using provided conditions' do
+      expect(relation.where(id: 1).to_a).
+        to eql([{ id: 1, title: "Joe's task" }])
+    end
+
+    it 'restricts relation using provided conditions and block' do
+      expect(relation.where(id: 1) { title.like("%Jane%") }.to_a).to be_empty
+    end
+
+    it 'restricts relation using provided conditions in a block' do
+      expect(relation.where { (id > 2) & title.like("%Jane%") }.to_a).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This adds access to schema attribute API in `where` and `having` blocks