### PR TITLE
Update to use dry-initializer instead of ROM::Options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rom', git: 'https://github.com/rom-rb/rom.git', branch: 'master'
-gem 'rom-support', git: 'https://github.com/rom-rb/rom-support.git', branch: 'master'
 
 group :test do
   gem 'byebug', platforms: :mri

--- a/lib/rom/sql/association.rb
+++ b/lib/rom/sql/association.rb
@@ -2,6 +2,7 @@ require 'dry/core/constants'
 require 'dry/core/class_attributes'
 
 require 'rom/types'
+require 'rom/initializer'
 require 'rom/sql/qualified_attribute'
 require 'rom/sql/association/name'
 
@@ -11,43 +12,46 @@ module ROM
     #
     # @api public
     class Association
+      include Dry::Core::Constants
       include Dry::Equalizer(:source, :target, :result)
-      include Options
+      extend Initializer
       extend Dry::Core::ClassAttributes
 
       defines :result
 
       # @!attribute [r] source
       #   @return [ROM::Relation::Name] the source relation name
-      attr_reader :source
+      param :source
 
       # @!attribute [r] target
       #   @return [ROM::Relation::Name] the target relation name
-      attr_reader :target
+      param :target
 
       # @!attribute [r] relation
       #   @return [Symbol] an optional relation identifier for the target
-      option :relation, accepts: [Symbol], reader: true
+      option :relation, Types::Strict::Symbol, reader: true, optional: true
 
       # @!attribute [r] result
       #   @return [Symbol] either :one or :many
-      option :result, accepts: [Symbol], reader: true, default: -> assoc { assoc.class.result }
+      option :result, Types::Strict::Symbol, reader: true, default: -> assoc { assoc.class.result }
 
       # @!attribute [r] as
       #   @return [Symbol] an optional association alias name
-      option :as, accepts: [Symbol], reader: true, default: -> assoc { assoc.target.to_sym }
+      option :as, Types::Strict::Symbol, reader: true, optional: true, default: -> assoc { assoc.target.to_sym }
 
       # @!attribute [r] foreign_key
       #   @return [Symbol] an optional association alias name
-      option :foreign_key, accepts: [Symbol], reader: true
+      option :foreign_key, Types::Strict::Symbol, optional: true, reader: true, default: proc { nil }
 
       alias_method :name, :as
 
-      # @api private
-      def initialize(source, target, options = EMPTY_HASH)
-        @source = Name[source]
-        @target = Name[options[:relation] || target, target, options[:as] || target]
-        super
+      # @api public
+      def self.new(source, target, options = EMPTY_HASH)
+        super(
+          Name[source],
+          Name[options[:relation] || target, target, options[:as] || target],
+          options
+        )
       end
 
       # Returns a qualified attribute name for a given dataset

--- a/lib/rom/sql/association.rb
+++ b/lib/rom/sql/association.rb
@@ -1,3 +1,7 @@
+require 'dry/core/constants'
+require 'dry/core/class_attributes'
+
+require 'rom/types'
 require 'rom/sql/qualified_attribute'
 require 'rom/sql/association/name'
 
@@ -9,7 +13,7 @@ module ROM
     class Association
       include Dry::Equalizer(:source, :target, :result)
       include Options
-      extend ClassMacros
+      extend Dry::Core::ClassAttributes
 
       defines :result
 

--- a/lib/rom/sql/association/many_to_many.rb
+++ b/lib/rom/sql/association/many_to_many.rb
@@ -1,12 +1,12 @@
+require 'rom/types'
+
 module ROM
   module SQL
     class Association
       class ManyToMany < Association
-        attr_reader :through
-
         result :many
 
-        option :through, default: nil, type: Symbol
+        option :through, type: Types::Strict::Symbol.optional
 
         # @api private
         def initialize(*)

--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -1,5 +1,8 @@
 require 'logger'
 
+require 'dry/core/constants'
+
+require 'rom/types'
 require 'rom/gateway'
 require 'rom/sql/migration'
 require 'rom/sql/commands'
@@ -16,7 +19,7 @@ module ROM
     #
     # @api public
     class Gateway < ROM::Gateway
-      include Options
+      include Dry::Core::Constants
       include Migration
 
       class << self
@@ -33,6 +36,9 @@ module ROM
       #
       # @api public
       attr_reader :logger
+
+      # @api private
+      attr_reader :options
 
       # SQL gateway interface
       #
@@ -55,14 +61,13 @@ module ROM
       #   gateway = ROM::SQL::Gateway.new(DB)
       #
       # @api public
-      def initialize(uri, options = {})
-        repo_options = self.class.option_definitions.names
-        conn_options = options.reject { |k, _| repo_options.include?(k) }
-
-        @connection = connect(uri, conn_options)
+      def initialize(uri, options = EMPTY_HASH)
+        @connection = connect(uri, options)
         load_extensions(Array(options[:extensions]))
 
-        super(uri, options.reject { |k, _| conn_options.keys.include?(k) })
+        @options = options
+
+        super
 
         self.class.instance = self
       end

--- a/lib/rom/sql/migration.rb
+++ b/lib/rom/sql/migration.rb
@@ -30,13 +30,12 @@ module ROM
     module Migration
       Sequel.extension :migration
 
-      def self.included(klass)
-        super
-        klass.class_eval do
-          option :migrator, reader: true, default: proc { |gateway|
-            Migrator.new(gateway.connection)
-          }
-        end
+      # @api public
+      attr_reader :migrator
+
+      # @api private
+      def initialize(uri, options = EMPTY_HASH)
+        @migrator = options.fetch(:migrator) { Migrator.new(connection) }
       end
 
       # @see ROM::SQL::Migration.pending?

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -1,20 +1,19 @@
+require 'pathname'
+require 'rom/types'
+require 'rom/initializer'
+
 module ROM
   module SQL
     module Migration
       class Migrator
-        include Options
+        extend Initializer
 
         DEFAULT_PATH = 'db/migrate'.freeze
         VERSION_FORMAT = '%Y%m%d%H%M%S'.freeze
 
-        option :path, reader: true, default: DEFAULT_PATH
+        param :connection
 
-        attr_reader :connection
-
-        def initialize(connection, options = {})
-          super
-          @connection = connection
-        end
+        option :path, type: ROM::Types.Definition(Pathname), reader: true, default: proc { DEFAULT_PATH }
 
         def run(options = {})
           Sequel::Migrator.run(connection, path.to_s, options)

--- a/lib/rom/sql/plugin/associates.rb
+++ b/lib/rom/sql/plugin/associates.rb
@@ -106,7 +106,7 @@ module ROM
                 "#{name} association is already defined for #{self.class}"
             end
 
-            option :association, reader: true, default: {}
+            option :association, reader: true, default: proc { Hash.new }
 
             include InstanceMethods
 

--- a/lib/rom/sql/plugin/pagination.rb
+++ b/lib/rom/sql/plugin/pagination.rb
@@ -1,20 +1,17 @@
+require 'rom/initializer'
+
 module ROM
   module SQL
     module Plugin
       module Pagination
         class Pager
-          include Options
+          extend Initializer
           include Dry::Equalizer(:dataset, :options)
 
-          option :current_page, reader: true, default: 1
+          param :dataset
+
+          option :current_page, reader: true, default: proc { 1 }
           option :per_page, reader: true
-
-          attr_reader :dataset
-
-          def initialize(dataset, options = {})
-            super
-            @dataset = dataset
-          end
 
           def next_page
             num = current_page + 1

--- a/lib/rom/sql/schema/inferrer.rb
+++ b/lib/rom/sql/schema/inferrer.rb
@@ -1,9 +1,11 @@
+require 'dry/core/class_attributes'
+
 module ROM
   module SQL
     class Schema < ROM::Schema
       # @api private
       class Inferrer
-        extend ClassMacros
+        extend Dry::Core::ClassAttributes
 
         defines :ruby_type_mapping, :numeric_pk_type, :db_type, :db_registry
 
@@ -51,7 +53,7 @@ module ROM
             end
           end.compact
 
-          [inferred.compact, columns.map(&:first) - inferred.map { |attr| attr.meta[:name] }]
+          [inferred, columns.map(&:first) - inferred.map { |attr| attr.meta[:name] }]
         end
 
         private

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-types', '~> 0.9'
   spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.3'
   spec.add_runtime_dependency 'rom', '~> 3.0.0.beta'
-  spec.add_runtime_dependency 'rom-support', '~> 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sequel', '~> 4.25'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-types', '~> 0.9'
-  spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.1'
+  spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.3'
   spec.add_runtime_dependency 'rom', '~> 3.0.0.beta'
   spec.add_runtime_dependency 'rom-support', '~> 2.0'
 

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
       migrator = double('migrator')
 
       expect(Sequel).to receive(:connect)
-        .with(uri, host: '127.0.0.1')
+        .with(uri, host: '127.0.0.1', migrator: migrator)
         .and_return(conn)
 
       gateway = ROM::SQL::Gateway.new(uri, migrator: migrator, host: '127.0.0.1')
 
-      expect(gateway.options).to eql(migrator: migrator)
+      expect(gateway.options).to eql(migrator: migrator, host: '127.0.0.1')
     end
 
     it 'allows extensions' do


### PR DESCRIPTION
### TODO

- [x] port associations
- [x] port pagination plugin
- [x] figure out a way to filter out non-sequel connection options
- [x] figure out a way to make `Associates` plugin work, as it needs to overwrite `initialize` method which is not supported by dry-initializer (yet)