### PR TITLE
Merge on to new Hash to simplify logic

### DIFF
--- a/lib/rom/sql/schema/associations_dsl.rb
+++ b/lib/rom/sql/schema/associations_dsl.rb
@@ -43,11 +43,11 @@ module ROM
         end
 
         def belongs_to(name, options = {})
-          many_to_one(dataset_name(name), options.merge(as: options[:as] || name))
+          many_to_one(dataset_name(name), {as: name}.merge(options))
         end
 
         def has_one(name, options = {})
-          one_to_one(dataset_name(name), options.merge(as: options[:as] || name))
+          one_to_one(dataset_name(name), {as: name}.merge(options))
         end
 
         def call


### PR DESCRIPTION
Rather than merging on top of options and then referencing its initial value for `as`,
we can simply define the default value inside a new `Hash`, and then merge the user
supplied options on top of it.