### PR TITLE
Raise a more helpful error when join table can't be found

### DIFF
--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -55,7 +55,7 @@ module ROM
 
       # @api public
       def join(name)
-        schema = relations.detect { |_, r|
+        schema = relations.detect(method(:join_table_not_found)) { |_, r|
           r.schema.name.dataset == name.to_sym
         }[1].schema
 
@@ -91,6 +91,12 @@ module ROM
           @primary_key_name = primary_key[0].meta[:name]
           @primary_key_names = primary_key.map { |type| type.meta[:name] }
         end
+      end
+
+      private
+
+      def join_table_not_found
+        raise ROM::SQL::Error, "can't join with '#{name}'; table not found"
       end
     end
   end

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -20,5 +20,11 @@ RSpec.describe ROM::Relation, '#inner_join' do
         relation.inner_join(:tasks, user_id: :id).to_a
       }.to raise_error(Sequel::DatabaseError, /ambiguous/)
     end
+
+    it "fails gracefully when the table can't be found" do
+      expect {
+        relation.inner_join(:task, user_id: :id)
+      }.to raise_error(ROM::SQL::Error, /\btask\b/)
+    end
   end
 end

--- a/spec/unit/relation/left_join_spec.rb
+++ b/spec/unit/relation/left_join_spec.rb
@@ -14,5 +14,11 @@ RSpec.describe ROM::Relation, '#left_join' do
         { name: 'Jane', title: "Jane's task" }
       ])
     end
+
+    it "fails gracefully when the table can't be found" do
+      expect {
+        relation.left_join(:task, user_id: :id)
+      }.to raise_error(ROM::SQL::Error, /\btask\b/)
+    end
   end
 end


### PR DESCRIPTION
I was trying to create some joins and kept getting this cryptic error:

```
NoMethodError: undefined method `[]' for nil:NilClass
  from /Users/george/.rvm/gems/ruby-2.3.3/bundler/gems/rom-sql-c46d3c34c071/lib/rom/sql/schema.rb:58:in `join'
  from /Users/george/.rvm/gems/ruby-2.3.3/bundler/gems/rom-sql-c46d3c34c071/lib/rom/sql/relation/reading.rb:541:in `block in __join__'
  from /Users/george/.rvm/gems/ruby-2.3.3/bundler/gems/rom-sql-c46d3c34c071/lib/rom/sql/relation/reading.rb:541:in `each'
  from /Users/george/.rvm/gems/ruby-2.3.3/bundler/gems/rom-sql-c46d3c34c071/lib/rom/sql/relation/reading.rb:541:in `reduce'
  from /Users/george/.rvm/gems/ruby-2.3.3/bundler/gems/rom-sql-c46d3c34c071/lib/rom/sql/relation/reading.rb:541:in `__join__'
  from /Users/george/.rvm/gems/ruby-2.3.3/bundler/gems/rom-sql-c46d3c34c071/lib/rom/sql/relation/reading.rb:436:in `left_join'
```

turns out that I was doing it wrong: `inner_join(:task, user_id: :id)`, when
actually I should have passed `:tasks` as the first argument (i.e. the name of
the table.) An easy mistake to make since my user actually only has one task,
so I'm used to thinking about 'user.task' in the singular, not plural.

This PR raises a more helpful error when you get the name of the table wrong...
except it doesn't actually work, because `ROM::SQL::Error` has some extra magic
with `original_exception` that prevents `raise ROM::SQL::Error, 'message'` from
working as you'd expect.

Before I finalise this I figured I'd open the PR and a) make sure this is
actually a change you'd accept and b) get some feedback on whether I'm better
off raising ROM::SQL::Error (with some tweaks or hacks to make it actually
work) or using a different error class altogether.