### PR TITLE
Allow all of Sequel::DataSet#join parameters

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -558,10 +558,10 @@ module ROM
         private
 
         # @api private
-        def __join__(type, other, opts = EMPTY_HASH, &block)
+        def __join__(type, other, join_cond = EMPTY_HASH, opts = EMPTY_HASH, &block)
           case other
           when Symbol, Association::Name
-            new(dataset.__send__(type, other.to_sym, opts, &block))
+            new(dataset.__send__(type, other.to_sym, join_cond, opts, &block))
           when Relation
             __send__(type, other.name.dataset, join_keys(other))
           else

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe ROM::Relation, '#inner_join' do
       ])
     end
 
+    it 'allows specifying table_aliases' do
+      relation.insert id: 3, name: 'Jade'
+
+      result = relation.
+                 inner_join(:tasks, {user_id: :id}, table_alias: :t1).
+                 select(:name, tasks[:title])
+
+      expect(result.schema.map(&:name)).to eql(%i[name title])
+
+      expect(result.to_a).to eql([
+        { name: 'Jane', title: "Jane's task" },
+        { name: 'Joe', title: "Joe's task" }
+      ])
+    end
+
     context 'with associations' do
       before do
         conf.relation(:users) do


### PR DESCRIPTION
Dataset#join takes four parameters, though the last is not often used.

The actual signature of the method is:
  `def join_table(type, table, expr=nil, options=OPTS, &block)`

where expr is the basic set of `on` parameters for the join
conditions, and OPTS is a set of table modifiers.

For docs, see https://github.com/jeremyevans/sequel/blob/master/lib/sequel/dataset/query.rb#L470-L528