### PR TITLE
Add support for inferring PG's hstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.0.1 to-be-released
+
+### Added
+
+* Support for inferring the PostgreSQL `hstore` data type (flash-gordon)
+
 ## v1.0.0 2017-01-29
 
 This release is based on rom core 3.0.0 with its improved Schema API, which is extended with SQL-specific features.

--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -24,7 +24,8 @@ module ROM
           'cidr' => Types::PG::IPAddress,
           'macaddr' => Types::String,
           'point' => Types::PG::PointT,
-          'xml' => Types::String
+          'xml' => Types::String,
+          'hstore' => Types::PG::HStore
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -2,7 +2,7 @@ require 'dry-types'
 require 'sequel'
 require 'ipaddr'
 
-Sequel.extension(*%i(pg_array pg_array_ops pg_json pg_json_ops))
+Sequel.extension(*%i(pg_array pg_array_ops pg_json pg_json_ops pg_hstore))
 
 module ROM
   module SQL
@@ -40,6 +40,11 @@ module ROM
         JSONBOp = Types.Constructor(Sequel::Postgres::JSONBOp, &Sequel.method(:pg_jsonb))
 
         JSONB = JSONBArray | JSONBHash | JSONBOp
+
+        # HStore
+
+        HStoreR = Types.Constructor(Hash, &:to_hash)
+        HStore = Types.Constructor(Sequel::Postgres::HStore, &Sequel.method(:hstore)).meta(read: HStoreR)
 
         Bytea = Types.Constructor(Sequel::SQL::Blob, &Sequel::SQL::Blob.method(:new))
 

--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -24,7 +24,7 @@ module ROM
       end
 
       CONNECTION_EXTENSIONS = {
-        postgres: %i(pg_array pg_json pg_enum)
+        postgres: %i(pg_array pg_json pg_enum pg_hstore)
       }.freeze
 
       # @!attribute [r] logger

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -141,4 +141,19 @@ RSpec.describe 'ROM::SQL::Types' do
       expect(described_class.meta[:read]['(7.5,30.5)']).to eql(point)
     end
   end
+
+  describe ROM::SQL::Types::PG::HStore do
+    let(:mapping) { Hash['hot' => 'cold'] }
+    let(:read_type) { described_class.meta[:read] }
+
+    it 'covertss data to Sequel::Postgres::HStore' do
+      expect(described_class[mapping]).to be_a Sequel::Postgres::HStore
+      expect(described_class[mapping]).to eql(Sequel.hstore(hot: :cold))
+    end
+
+    it 'reads Sequel::Postgres::HStore as a Hash object' do
+      expect(read_type[Sequel.hstore(mapping)]).to eql(mapping)
+      expect(read_type[Sequel.hstore(mapping)]).to be_a(Hash)
+    end
+  end
 end

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
       extensions = [:pg_array, :pg_array_ops]
       connection = Sequel.connect uri
 
-      expect(connection).to receive(:extension).with(:pg_array, :pg_json, :pg_enum, :pg_array_ops)
+      expect(connection).to receive(:extension).with(:pg_array, :pg_json, :pg_enum, :pg_hstore, :pg_array_ops)
       expect(connection).to receive(:extension).with(:freeze_datasets) unless RUBY_ENGINE == 'rbx'
 
       ROM::SQL::Gateway.new(connection, extensions: extensions)


### PR DESCRIPTION
fixes #140 

I think we need a way to cherry-pick Sequel's extensions depending on what data types we found during the schema inference. I'll try to come up with something, but I guess it's gonna be tricky