### PR TITLE
Add support for more PG geometric types

### DIFF
--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -28,7 +28,8 @@ module ROM
           'hstore' => Types::PG::HStore,
           'line' => Types::PG::LineT,
           'circle' => Types::PG::CircleT,
-          'box' => Types::PG::BoxT
+          'box' => Types::PG::BoxT,
+          'lseg' => Types::PG::LineSegmentT
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -30,7 +30,8 @@ module ROM
           'circle' => Types::PG::CircleT,
           'box' => Types::PG::BoxT,
           'lseg' => Types::PG::LineSegmentT,
-          'polygon' => Types::PG::PolygonT
+          'polygon' => Types::PG::PolygonT,
+          'path' => Types::PG::PathT
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -26,7 +26,8 @@ module ROM
           'point' => Types::PG::PointT,
           'xml' => Types::String,
           'hstore' => Types::PG::HStore,
-          'line' => Types::PG::LineT
+          'line' => Types::PG::LineT,
+          'circle' => Types::PG::CircleT
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -29,7 +29,8 @@ module ROM
           'line' => Types::PG::LineT,
           'circle' => Types::PG::CircleT,
           'box' => Types::PG::BoxT,
-          'lseg' => Types::PG::LineSegmentT
+          'lseg' => Types::PG::LineSegmentT,
+          'polygon' => Types::PG::PolygonT
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -25,7 +25,8 @@ module ROM
           'macaddr' => Types::String,
           'point' => Types::PG::PointT,
           'xml' => Types::String,
-          'hstore' => Types::PG::HStore
+          'hstore' => Types::PG::HStore,
+          'line' => Types::PG::LineT
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/inferrer.rb
+++ b/lib/rom/sql/extensions/postgres/inferrer.rb
@@ -27,7 +27,8 @@ module ROM
           'xml' => Types::String,
           'hstore' => Types::PG::HStore,
           'line' => Types::PG::LineT,
-          'circle' => Types::PG::CircleT
+          'circle' => Types::PG::CircleT,
+          'box' => Types::PG::BoxT
         ).freeze
 
         db_array_type_matcher Sequel::Postgres::PGArray::EMPTY_BRACKET

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -57,6 +57,8 @@ module ROM
 
         Point = ::Struct.new(:x, :y)
 
+        PointD = Types.Definition(Point)
+
         PointTR = Types.Constructor(Point) do |p|
           x, y = p.to_s[1...-1].split(',', 2)
           Point.new(Float(x), Float(y))
@@ -107,6 +109,18 @@ module ROM
         LineSegmentT = Types.Constructor(LineSegment) do |lseg|
           "[(#{ lseg.begin.x },#{ lseg.begin.y }),(#{ lseg.end.x },#{ lseg.end.y })]"
         end.meta(read: LineSegmentTR)
+
+        Polygon = Types::Strict::Array.member(PointD)
+
+        PolygonTR = Polygon.constructor do |p|
+          coordinates = p.to_s.gsub(/[()\s]/, '').split(',').each_slice(2)
+          points = coordinates.map { |x, y| Point.new(Float(x), Float(y)) }
+          Polygon[points]
+        end
+
+        PolygonT = Types.Constructor(::String) do |polygon|
+          '(' + polygon.map { |p| "(#{ p.x },#{ p.y })" }.join(',') + ')'
+        end.meta(read: PolygonTR)
       end
     end
   end

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -77,7 +77,7 @@ module ROM
         Circle = ::Struct.new(:center, :radius)
 
         CircleTR = Types.Constructor(Circle) do |c|
-          x, y, r = c.to_s.gsub(/[\(\)<>\s]/, '').split(',', 3)
+          x, y, r = c.to_s.gsub(/[()<>\s]/, '').split(',', 3)
           center = Point.new(Float(x), Float(y))
           Circle.new(center, Float(r))
         end

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -54,6 +54,8 @@ module ROM
 
         Money = Types::Decimal
 
+        # Geometric types
+
         Point = ::Struct.new(:x, :y)
 
         PointTR = Types.Constructor(Point) do |p|
@@ -62,6 +64,15 @@ module ROM
         end
 
         PointT = Types.Constructor(Point) { |p| "(#{ p.x },#{ p.y })" }.meta(read: PointTR)
+
+        Line = ::Struct.new(:a, :b, :c)
+
+        LineTR = Types.Constructor(Line) do |ln|
+          a, b, c = ln.to_s[1..-2].split(',', 3)
+          Line.new(Float(a), Float(b), Float(c))
+        end
+
+        LineT = Types.Constructor(Line) { |ln| "{#{ ln.a },#{ ln.b },#{ln.c}}"}.meta(read: LineTR)
       end
     end
   end

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -14,8 +14,7 @@ module ROM
 
         # Array
 
-        Array = Dry::Types::Definition
-                .new(Sequel::Postgres::PGArray)
+        Array = Types.Definition(Sequel::Postgres::PGArray)
 
         def self.Array(db_type)
           Array.constructor(-> (v) { Sequel.pg_array(v, db_type) }).meta(type: db_type)

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -73,6 +73,16 @@ module ROM
         end
 
         LineT = Types.Constructor(Line) { |ln| "{#{ ln.a },#{ ln.b },#{ln.c}}"}.meta(read: LineTR)
+
+        Circle = ::Struct.new(:center, :radius)
+
+        CircleTR = Types.Constructor(Circle) do |c|
+          x, y, r = c.to_s.gsub(/[\(\)<>\s]/, '').split(',', 3)
+          center = Point.new(Float(x), Float(y))
+          Circle.new(center, Float(r))
+        end
+
+        CircleT = Types.Constructor(Circle) { |c| "<(#{ c.center.x },#{ c.center.y }),#{ c.radius }>" }.meta(read: CircleTR)
       end
     end
   end

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -83,6 +83,18 @@ module ROM
         end
 
         CircleT = Types.Constructor(Circle) { |c| "<(#{ c.center.x },#{ c.center.y }),#{ c.radius }>" }.meta(read: CircleTR)
+
+        Box = ::Struct.new(:upper_right, :lower_left)
+
+        BoxTR = Types.Constructor(Box) do |b|
+          x_right, y_right, x_left, y_left = b.to_s.gsub(/[()\s]/, '').split(',', 4)
+
+          upper_right = Point.new(Float(x_right), Float(y_right))
+          lower_left = Point.new(Float(x_left), Float(y_left))
+          Box.new(upper_right, lower_left)
+        end
+
+        BoxT = Types.Constructor(Box) { |b| "((#{ b.upper_right.x },#{ b.upper_right.y }),(#{ b.lower_left.x },#{ b.lower_left.y }))" }.meta(read: BoxTR)
       end
     end
   end

--- a/lib/rom/sql/extensions/postgres/types.rb
+++ b/lib/rom/sql/extensions/postgres/types.rb
@@ -95,6 +95,19 @@ module ROM
         end
 
         BoxT = Types.Constructor(Box) { |b| "((#{ b.upper_right.x },#{ b.upper_right.y }),(#{ b.lower_left.x },#{ b.lower_left.y }))" }.meta(read: BoxTR)
+
+        LineSegment = ::Struct.new(:begin, :end)
+
+        LineSegmentTR = Types.Constructor(LineSegment) do |lseg|
+          x_begin, y_begin, x_end, y_end = lseg.to_s.gsub(/[\[\]()\s]/, '').split(',', 4)
+          point_begin = Point.new(Float(x_begin), Float(y_begin))
+          point_end = Point.new(Float(x_end), Float(y_end))
+          LineSegment.new(point_begin, point_end)
+        end
+
+        LineSegmentT = Types.Constructor(LineSegment) do |lseg|
+          "[(#{ lseg.begin.x },#{ lseg.begin.y }),(#{ lseg.end.x },#{ lseg.end.y })]"
+        end.meta(read: LineSegmentTR)
       end
     end
   end

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -9,6 +9,10 @@ module ROM
         ROM::Types.Constructor(*args, &block)
       end
 
+      def self.Definition(*args, &block)
+        ROM::Types.Definition(*args, &block)
+      end
+
       Serial = Int.meta(primary_key: true)
 
       Blob = Constructor(Sequel::SQL::Blob, &Sequel::SQL::Blob.method(:new))

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -215,15 +215,38 @@ RSpec.describe 'ROM::SQL::Types' do
   describe ROM::SQL::Types::PG::PolygonT do
     let(:first) { ROM::SQL::Types::PG::Point.new(8.5, 30.5) }
     let(:second) { ROM::SQL::Types::PG::Point.new(7.5, 20.5) }
+    let(:third) { ROM::SQL::Types::PG::Point.new(6.5, 10.5) }
 
-    let(:polygon) { ROM::SQL::Types::PG::Polygon[[first, second]] }
+    let(:polygon) { ROM::SQL::Types::PG::Polygon[[first, second, third]] }
 
-    it 'serializes a polygon using ( ( x1 , y1 ) , ( x2 , y2 ) ) format' do
-      expect(described_class[polygon]).to eql('((8.5,30.5),(7.5,20.5))')
+    it 'serializes a polygon using ( ( x1 , y1 ) ... ( xn , yn ) ) format' do
+      expect(described_class[polygon]).to eql('((8.5,30.5),(7.5,20.5),(6.5,10.5))')
     end
 
     it 'reads serialized format' do
-      expect(described_class.meta[:read]['((8.5,30.5),(7.5,20.5))']).to eql(polygon)
+      expect(described_class.meta[:read]['((8.5,30.5),(7.5,20.5),(6.5,10.5))']).to eql(polygon)
+    end
+  end
+
+  describe ROM::SQL::Types::PG::PathT do
+    let(:first) { ROM::SQL::Types::PG::Point.new(8.5, 30.5) }
+    let(:second) { ROM::SQL::Types::PG::Point.new(7.5, 20.5) }
+    let(:third) { ROM::SQL::Types::PG::Point.new(6.5, 10.5) }
+
+    let(:closed_path) { ROM::SQL::Types::PG::Path.new([first, second, third], :closed) }
+    let(:open_path) { ROM::SQL::Types::PG::Path.new([first, second, third], :open) }
+
+    it 'serializes a closed path using ( ( x1 , y1 ) ... ( xn , yn ) ) format' do
+      expect(described_class[closed_path]).to eql('((8.5,30.5),(7.5,20.5),(6.5,10.5))')
+    end
+
+    it 'serializes an open path' do
+      expect(described_class[open_path]).to eql('[(8.5,30.5),(7.5,20.5),(6.5,10.5)]')
+    end
+
+    it 'reads serialized format' do
+      expect(described_class.meta[:read]['((8.5,30.5),(7.5,20.5),(6.5,10.5))']).to eql(closed_path)
+      expect(described_class.meta[:read]['[(8.5,30.5),(7.5,20.5),(6.5,10.5)]']).to eql(open_path)
     end
   end
 end

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -211,4 +211,19 @@ RSpec.describe 'ROM::SQL::Types' do
       expect(described_class.meta[:read]['[(8.5,30.5),(7.5,20.5)]']).to eql(lseg)
     end
   end
+
+  describe ROM::SQL::Types::PG::PolygonT do
+    let(:first) { ROM::SQL::Types::PG::Point.new(8.5, 30.5) }
+    let(:second) { ROM::SQL::Types::PG::Point.new(7.5, 20.5) }
+
+    let(:polygon) { ROM::SQL::Types::PG::Polygon[[first, second]] }
+
+    it 'serializes a polygon using ( ( x1 , y1 ) , ( x2 , y2 ) ) format' do
+      expect(described_class[polygon]).to eql('((8.5,30.5),(7.5,20.5))')
+    end
+
+    it 'reads serialized format' do
+      expect(described_class.meta[:read]['((8.5,30.5),(7.5,20.5))']).to eql(polygon)
+    end
+  end
 end

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -168,4 +168,17 @@ RSpec.describe 'ROM::SQL::Types' do
       expect(described_class.meta[:read]['{2.3,4.9,3.1415}']).to eql(line)
     end
   end
+
+  describe ROM::SQL::Types::PG::CircleT do
+    let(:center) { ROM::SQL::Types::PG::Point.new(7.5, 30.5) }
+    let(:circle) { ROM::SQL::Types::PG::Circle.new(center, 1.2) }
+
+    it 'serializes a circle using the <(x,y),r> format' do
+      expect(described_class[circle]).to eql('<(7.5,30.5),1.2>')
+    end
+
+    it 'reads the <(x,y),r> format' do
+      expect(described_class.meta[:read]['<(7.5,30.5),1.2>']).to eql(circle)
+    end
+  end
 end

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -181,4 +181,19 @@ RSpec.describe 'ROM::SQL::Types' do
       expect(described_class.meta[:read]['<(7.5,30.5),1.2>']).to eql(circle)
     end
   end
+
+  describe ROM::SQL::Types::PG::BoxT do
+    let(:lower_left) { ROM::SQL::Types::PG::Point.new(7.5, 20.5) }
+    let(:upper_right) { ROM::SQL::Types::PG::Point.new(8.5, 30.5) }
+
+    let(:box) { ROM::SQL::Types::PG::Box.new(upper_right, lower_left) }
+
+    it 'serializes a box' do
+      expect(described_class[box]).to eql('((8.5,30.5),(7.5,20.5))')
+    end
+
+    it 'reads serialized format' do
+      expect(described_class.meta[:read]['((8.5,30.5),(7.5,20.5))']).to eql(box)
+    end
+  end
 end

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -196,4 +196,19 @@ RSpec.describe 'ROM::SQL::Types' do
       expect(described_class.meta[:read]['((8.5,30.5),(7.5,20.5))']).to eql(box)
     end
   end
+
+  describe ROM::SQL::Types::PG::LineSegmentT do
+    let(:first) { ROM::SQL::Types::PG::Point.new(8.5, 30.5) }
+    let(:second) { ROM::SQL::Types::PG::Point.new(7.5, 20.5) }
+
+    let(:lseg) { ROM::SQL::Types::PG::LineSegment.new(first, second) }
+
+    it 'serializes a lseg using [ ( x1 , y1 ) , ( x2 , y2 ) ] format' do
+      expect(described_class[lseg]).to eql('[(8.5,30.5),(7.5,20.5)]')
+    end
+
+    it 'reads serialized format' do
+      expect(described_class.meta[:read]['[(8.5,30.5),(7.5,20.5)]']).to eql(lseg)
+    end
+  end
 end

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -156,4 +156,16 @@ RSpec.describe 'ROM::SQL::Types' do
       expect(read_type[Sequel.hstore(mapping)]).to be_a(Hash)
     end
   end
+
+  describe ROM::SQL::Types::PG::LineT do
+    let(:line) { ROM::SQL::Types::PG::Line.new(2.3, 4.9, 3.1415) }
+
+    it 'serializes a line using the {A,B,C} format' do
+      expect(described_class[line]).to eql('{2.3,4.9,3.1415}')
+    end
+
+    it 'reads the {A,B,C} format' do
+      expect(described_class.meta[:read]['{2.3,4.9,3.1415}']).to eql(line)
+    end
+  end
 end

--- a/spec/integration/schema/inferrer/postgres_spec.rb
+++ b/spec/integration/schema/inferrer/postgres_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
       box :box
       lseg :lseg
       polygon :polygon
+      path :path
     end
   end
 
@@ -107,6 +108,11 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
           name: :polygon,
           source: source,
           read: ROM::SQL::Types::PG::PolygonTR.optional
+        ),
+        path: ROM::SQL::Types::PG::PathT.optional.meta(
+          name: :path,
+          source: source,
+          read: ROM::SQL::Types::PG::PathTR.optional
         )
       )
     end
@@ -138,6 +144,8 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
         box :box
         lseg :lseg
         polygon :polygon
+        path :closed_path
+        path :open_path
       end
 
       conf.relation(:test_bidirectional) { schema(infer: true) }
@@ -164,6 +172,8 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
       ROM::SQL::Types::PG::Box.new(upper_left, lower_right)
     end
     let(:polygon) { ROM::SQL::Types::PG::Polygon[[point, point_2]] }
+    let(:closed_path) { ROM::SQL::Types::PG::Path.new([point, point_2], :closed) }
+    let(:open_path) { ROM::SQL::Types::PG::Path.new([point, point_2], :open) }
 
     let(:relation) { container.relations[:test_bidirectional] }
     let(:create) { commands[:test_bidirectional].create }
@@ -173,12 +183,12 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
       inserted = create.call(
         id: 1, center: point, ip: dns, mapping: mapping,
         line: line, circle: circle, lseg: lseg, box: box,
-        polygon: polygon
+        polygon: polygon, closed_path: closed_path, open_path: open_path
       )
       expect(inserted).to eql(
         id: 1, center: point, ip: dns, mapping: mapping,
         line: line, circle: circle, lseg: lseg, box: box_corrected,
-        polygon: polygon
+        polygon: polygon, closed_path: closed_path, open_path: open_path
       )
       expect(relation.to_a).to eql([inserted])
     end

--- a/spec/integration/schema/inferrer/postgres_spec.rb
+++ b/spec/integration/schema/inferrer/postgres_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
       xml :page
       hstore :mapping
       line :line
+      circle :circle
     end
   end
 
@@ -83,6 +84,11 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
           name: :line,
           source: source,
           read: ROM::SQL::Types::PG::LineTR.optional
+        ),
+        circle: ROM::SQL::Types::PG::CircleT.optional.meta(
+          name: :circle,
+          source: source,
+          read: ROM::SQL::Types::PG::CircleTR.optional
         )
       )
     end
@@ -110,6 +116,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
         point :center
         hstore :mapping
         line :line
+        circle :circle
       end
 
       conf.relation(:test_bidirectional) { schema(infer: true) }
@@ -125,13 +132,14 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
     let(:line) { ROM::SQL::Types::PG::Line.new(2.3, 4.9, 3.1415) }
     let(:dns) { IPAddr.new('8.8.8.8') }
     let(:mapping) { Hash['hot' => 'cold'] }
+    let(:circle) { ROM::SQL::Types::PG::Circle.new(point, 1.0) }
 
     let(:relation) { container.relations[:test_bidirectional] }
     let(:create) { commands[:test_bidirectional].create }
 
     it 'writes and reads data' do
-      inserted = create.call(id: 1, center: point, ip: dns, mapping: mapping, line: line)
-      expect(inserted).to eql(id: 1, center: point, ip: dns, mapping: mapping, line: line)
+      inserted = create.call(id: 1, center: point, ip: dns, mapping: mapping, line: line, circle: circle)
+      expect(inserted).to eql(id: 1, center: point, ip: dns, mapping: mapping, line: line, circle: circle)
       expect(relation.to_a).to eql([inserted])
     end
   end

--- a/spec/integration/schema/inferrer/postgres_spec.rb
+++ b/spec/integration/schema/inferrer/postgres_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
       circle :circle
       box :box
       lseg :lseg
+      polygon :polygon
     end
   end
 
@@ -101,6 +102,11 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
           name: :lseg,
           source: source,
           read: ROM::SQL::Types::PG::LineSegmentTR.optional
+        ),
+        polygon: ROM::SQL::Types::PG::PolygonT.optional.meta(
+          name: :polygon,
+          source: source,
+          read: ROM::SQL::Types::PG::PolygonTR.optional
         )
       )
     end
@@ -131,6 +137,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
         circle :circle
         box :box
         lseg :lseg
+        polygon :polygon
       end
 
       conf.relation(:test_bidirectional) { schema(infer: true) }
@@ -156,14 +163,23 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
 
       ROM::SQL::Types::PG::Box.new(upper_left, lower_right)
     end
+    let(:polygon) { ROM::SQL::Types::PG::Polygon[[point, point_2]] }
 
     let(:relation) { container.relations[:test_bidirectional] }
     let(:create) { commands[:test_bidirectional].create }
 
     it 'writes and reads data & corrects data' do
       # Box coordinates are reordered if necessary
-      inserted = create.call(id: 1, center: point, ip: dns, mapping: mapping, line: line, circle: circle, lseg: lseg, box: box)
-      expect(inserted).to eql(id: 1, center: point, ip: dns, mapping: mapping, line: line, circle: circle, lseg: lseg, box: box_corrected)
+      inserted = create.call(
+        id: 1, center: point, ip: dns, mapping: mapping,
+        line: line, circle: circle, lseg: lseg, box: box,
+        polygon: polygon
+      )
+      expect(inserted).to eql(
+        id: 1, center: point, ip: dns, mapping: mapping,
+        line: line, circle: circle, lseg: lseg, box: box_corrected,
+        polygon: polygon
+      )
       expect(relation.to_a).to eql([inserted])
     end
   end

--- a/spec/integration/schema/inferrer/postgres_spec.rb
+++ b/spec/integration/schema/inferrer/postgres_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
       point :center
       xml :page
       hstore :mapping
+      line :line
     end
   end
 
@@ -77,6 +78,11 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
           name: :mapping,
           source: source,
           read: ROM::SQL::Types::PG::HStoreR.optional
+        ),
+        line: ROM::SQL::Types::PG::LineT.optional.meta(
+          name: :line,
+          source: source,
+          read: ROM::SQL::Types::PG::LineTR.optional
         )
       )
     end
@@ -103,6 +109,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
         inet :ip
         point :center
         hstore :mapping
+        line :line
       end
 
       conf.relation(:test_bidirectional) { schema(infer: true) }
@@ -115,6 +122,7 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
     end
 
     let(:point) { ROM::SQL::Types::PG::Point.new(7.5, 30.5) }
+    let(:line) { ROM::SQL::Types::PG::Line.new(2.3, 4.9, 3.1415) }
     let(:dns) { IPAddr.new('8.8.8.8') }
     let(:mapping) { Hash['hot' => 'cold'] }
 
@@ -122,8 +130,8 @@ RSpec.describe 'ROM::SQL::Schema::PostgresInferrer', :postgres do
     let(:create) { commands[:test_bidirectional].create }
 
     it 'writes and reads data' do
-      inserted = create.call(id: 1, center: point, ip: dns, mapping: mapping)
-      expect(inserted).to eql(id: 1, center: point, ip: dns, mapping: mapping)
+      inserted = create.call(id: 1, center: point, ip: dns, mapping: mapping, line: line)
+      expect(inserted).to eql(id: 1, center: point, ip: dns, mapping: mapping, line: line)
       expect(relation.to_a).to eql([inserted])
     end
   end


### PR DESCRIPTION
Closes #141

This PR adds support for more PG [geometric types](https://www.postgresql.org/docs/9.6/static/datatype-geometric.html).

Supported geometric types:

- [x] point (`ROM::SQL::Types::PG::Point.new(x, y)`)

New:

- [x] line (`ROM::SQL::Types::PG::Line.new(a, b, c)`)
- [x] lseg (`ROM::SQL::Types::PG::LineSegment.new(point, point_2)`)
- [x] box (`ROM::SQL::Types::PG::Box.new(upper_left, lower_right)`)
- [x] open path (`ROM::SQL::Types::PG::Path.new([point, point_2, ...], :open)` 
- [x] closed path (`ROM::SQL::Types::PG::Path.new([point, point_2, ...], :closed)`)
- [x] polygon (`ROM::SQL::Types::PG::Polygon[[point, point_2, ...]]`)
- [x] circle (`ROM::SQL::Types::PG::Circle.new(center, radius)`)

