### PR TITLE
Add ROM::SQL::Attribute#in for range checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support for inferring the PostgreSQL `hstore` data type (flash-gordon)
 * Support for the rest of geometric PostgreSQL data types (box, lseg, polygon, etc.) (Morozzzko)
 * Added inferring for timestamp types with specified precision (flash-gordon)
+* Added `ROM::SQL::Attribute#in` to support range checks in conditions (flash-gordon)
 
 ### Fixed
 

--- a/spec/unit/relation/where_spec.rb
+++ b/spec/unit/relation/where_spec.rb
@@ -29,5 +29,28 @@ RSpec.describe ROM::Relation, '#where' do
       expect(relation.where { id.is(1) | id.is(2) }.to_a).
         to eql([{ id: 1, title: "Joe's task" }, { id: 2, title: "Jane's task" }])
     end
+
+    it 'restricts with a range condition' do
+      expect(relation.where { id.in(-1...2) }.to_a).
+        to eql([{ id: 1, title: "Joe's task" }])
+
+      expect(relation.where { id.in(0...3) }.to_a).
+        to eql([{ id: 1, title: "Joe's task" }, { id: 2, title: "Jane's task" }])
+    end
+
+    it 'restricts with an inclusive range' do
+      expect(relation.where { id.in(0..2) }.to_a).
+        to eql([{ id: 1, title: "Joe's task" }, { id: 2, title: "Jane's task" }])
+    end
+
+    it 'restricts with an ordinary enum' do
+      expect(relation.where { id.in(2, 3) }.to_a).
+        to eql([{ id: 2, title: "Jane's task" }])
+    end
+
+    it 'restricts with enum using self syntax' do
+      expect(relation.where(relation[:id].in(2, 3)).to_a).
+        to eql([{ id: 2, title: "Jane's task" }])
+    end
   end
 end


### PR DESCRIPTION
This adds a nice syntax for range checks. Some examples to get the idea:

```ruby
users.where { id.in(1..100) | created_at(((Time.now - 86400)..Time.now)) }
users.where { id.in(1, 2, 3) }
users.where(users[:id].in(1, 2, 3))
```

/cc @solnic 