### PR TITLE
Fix the usage of timestamp in command chains

### DIFF
--- a/lib/rom/sql/plugin/timestamps.rb
+++ b/lib/rom/sql/plugin/timestamps.rb
@@ -96,7 +96,7 @@ module ROM
           # @return [Array<Hash>, Hash]
           #
           # @api private
-          def set_timestamps(tuples, *ignored)
+          def set_timestamps(tuples, *)
             timestamps = build_timestamps
 
             case tuples

--- a/lib/rom/sql/plugin/timestamps.rb
+++ b/lib/rom/sql/plugin/timestamps.rb
@@ -96,7 +96,7 @@ module ROM
           # @return [Array<Hash>, Hash]
           #
           # @api private
-          def set_timestamps(tuples)
+          def set_timestamps(tuples, *ignored)
             timestamps = build_timestamps
 
             case tuples

--- a/spec/shared/notes.rb
+++ b/spec/shared/notes.rb
@@ -1,5 +1,4 @@
 RSpec.shared_context 'notes' do
-  include_context 'database setup'
 
   before do
     inferrable_relations.concat %i(notes)
@@ -10,6 +9,7 @@ RSpec.shared_context 'notes' do
 
     conn.create_table :notes do
       primary_key :id
+      foreign_key :user_id, :users
       String :text, null: false
       # TODO: Remove Oracle's workarounds once inferer can infer not-null timestamps
       DateTime :created_at, null: ctx.oracle?(example)


### PR DESCRIPTION
When triggered as a part of a command chain, `before` methods are called
with multiple arguments.  The initial implementation of `timestamp` as a
before filter did not take this into account.

```ruby
  create_task = rom.commands(:tasks).create_with_user
  create_user = rom.commands(:users).create.with(name: "John")

  (create_user >> create_task).call(name: "do the dishes")

  # ArgumentError:
  #   wrong number of arguments (given 2, expected 1)
  # ./lib/rom/sql/plugin/timestamps.rb:99:in `set_timestamps'
```

This fixes the filter method to address this case

Fixes #152 