### PR TITLE
Add support for joins by association name

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -811,7 +811,12 @@ module ROM
         def __join__(type, other, join_cond = EMPTY_HASH, opts = EMPTY_HASH, &block)
           case other
           when Symbol, Association::Name
-            new(dataset.__send__(type, other.to_sym, join_cond, opts, &block))
+            if join_cond.empty?
+              assoc = associations[other]
+              assoc.join(__registry__, type, self, __registry__[assoc.target.relation])
+            else
+              new(dataset.__send__(type, other.to_sym, join_cond, opts, &block))
+            end
           when Relation
             associations[other.name.dataset].join(__registry__, type, self, other)
           else

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -41,7 +41,10 @@ RSpec.describe ROM::Relation, '#inner_join' do
       before do
         conf.relation(:users) do
           schema(infer: true) do
-            associations { has_many :tasks }
+            associations do
+              has_many :tasks
+              has_many :tasks, as: :todos, relation: :tasks
+            end
           end
         end
 
@@ -84,6 +87,22 @@ RSpec.describe ROM::Relation, '#inner_join' do
         result = tasks.inner_join(tags)
 
         expect(result.to_a).to eql([{ id: 1, user_id: 2, title: "Joe's task" }])
+      end
+
+      it 'joins by association name if no condition provided' do
+        result = relation.
+                   inner_join(:tasks).
+                   select(:name, tasks[:title])
+
+        expect(result.schema.map(&:name)).to eql(%i[name title])
+      end
+
+      it 'joins if association name differs from relation name' do
+        result = relation.
+                   inner_join(:todos).
+                   select(:name, tasks[:title])
+
+        expect(result.schema.map(&:name)).to eql(%i[name title])
       end
     end
 

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe ROM::Relation, '#inner_join' do
 
   let(:tasks) { relations[:tasks] }
   let(:tags) { relations[:tags] }
+  let(:puzzles) { relations[:puzzles] }
 
   include_context 'users and tasks'
 
@@ -39,6 +40,16 @@ RSpec.describe ROM::Relation, '#inner_join' do
 
     context 'with associations' do
       before do
+        inferrable_relations.concat %i(puzzles)
+      end
+
+      before do
+        conn.create_table(:puzzles) do
+          primary_key :id
+          foreign_key :author_id, :users, null: false
+          column :text, String, null: false
+        end
+
         conf.relation(:users) do
           schema(infer: true) do
             associations do
@@ -67,7 +78,16 @@ RSpec.describe ROM::Relation, '#inner_join' do
           end
         end
 
+        conf.relation(:puzzles) do
+          schema(infer: true) do
+            associations do
+              belongs_to :users, as: :author
+            end
+          end
+        end
+
         relation.insert id: 3, name: 'Jade'
+        puzzles.insert id: 1, author_id: 1, text: 'solved by Jane'
       end
 
       it 'joins relation with join keys inferred' do
@@ -95,6 +115,11 @@ RSpec.describe ROM::Relation, '#inner_join' do
                    select(:name, tasks[:title])
 
         expect(result.schema.map(&:name)).to eql(%i[name title])
+
+        expect(result.to_a).to eql([
+                                     { name: 'Jane', title: "Jane's task" },
+                                     { name: 'Joe', title: "Joe's task" }
+                                   ])
       end
 
       it 'joins if association name differs from relation name' do
@@ -103,6 +128,17 @@ RSpec.describe ROM::Relation, '#inner_join' do
                    select(:name, tasks[:title])
 
         expect(result.schema.map(&:name)).to eql(%i[name title])
+
+        expect(result.to_a).to eql([
+                                     { name: 'Jane', title: "Jane's task" },
+                                     { name: 'Joe', title: "Joe's task" }
+                                   ])
+      end
+
+      it 'joins by relation if association name differs from relation name' do
+        result = puzzles.inner_join(users).select(:name, puzzles[:text])
+
+        expect(result.to_a).to eql([ name: 'Jane', title: "Jane's task" ])
       end
     end
 

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe ROM::Relation, '#inner_join' do
       end
 
       it 'joins by relation if association name differs from relation name' do
+        pending 'waits for support for joins by aliased relation'
         result = puzzles.inner_join(users).select(:name, puzzles[:text])
 
         expect(result.to_a).to eql([ name: 'Jane', title: "Jane's task" ])


### PR DESCRIPTION
Since association carries all info we need for a join it seems reasonable to infer join condition automatically.