### PR TITLE
Call inner joins with relation proxy objects too

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -809,15 +809,14 @@ module ROM
         #
         # @api private
         def __join__(type, other, join_cond = EMPTY_HASH, opts = EMPTY_HASH, &block)
-          case other
-          when Symbol, Association::Name
+          if other.is_a?(Symbol) || other.is_a?(Association::Name)
             if join_cond.empty?
               assoc = associations[other]
               assoc.join(__registry__, type, self, __registry__[assoc.target.relation])
             else
               new(dataset.__send__(type, other.to_sym, join_cond, opts, &block))
             end
-          when Relation
+          elsif other.respond_to?(:name) && other.name.is_a?(Relation::Name)
             associations[other.name.dataset].join(__registry__, type, self, other)
           else
             raise ArgumentError, "+other+ must be either a symbol or a relation, #{other.class} given"

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -103,6 +103,21 @@ RSpec.describe ROM::Relation, '#inner_join' do
                                    ])
       end
 
+      let(:task_relation_proxy) { Class.new{ def name; ROM::Relation::Name.new(:tasks); end }.new }
+
+      it 'joins relation with relation proxy objects' do
+        result = relation.
+                   inner_join(task_relation_proxy).
+                   select(:name, tasks[:title])
+
+        expect(result.schema.map(&:name)).to eql(%i[name title])
+
+        expect(result.to_a).to eql([
+                                     { name: 'Jane', title: "Jane's task" },
+                                     { name: 'Joe', title: "Joe's task" }
+                                   ])
+      end
+
       it 'joins relation with join keys inferred for m:m-through' do
         result = tasks.inner_join(tags)
 


### PR DESCRIPTION
With this patch, we can call `#inner_join` method with `RelationProxy`
(instance of repository) objects too.

Reference to https://github.com/rom-rb/rom-sql/issues/172