### PR TITLE
Remove global Gateway.instance

### DIFF
--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -17,12 +17,6 @@ module ROM
       include Dry::Core::Constants
       include Migration
 
-      class << self
-        # FIXME: get rid of this and figure out a nicer way of handling migration DSL
-        # we want to have global access ONLY when running migration tasks
-        attr_accessor :instance
-      end
-
       adapter :sql
 
       CONNECTION_EXTENSIONS = {
@@ -96,8 +90,6 @@ module ROM
         @options = options
 
         super
-
-        self.class.instance = self
       end
 
       # Disconnect from the gateway's database

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -16,7 +16,7 @@ module ROM
         private
 
         def gateway
-          ROM::SQL::Gateway.instance
+          ROM::SQL::RakeSupport.env.gateways[:default]
         end
       end
     end

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -1,24 +1,55 @@
-RSpec.describe ROM::SQL, '.migration', :postgres do
+RSpec.describe ROM::SQL, '.migration' do
   include_context 'database setup'
 
   before do
     inferrable_relations.concat %i(dragons schema_migrations)
   end
 
-  before { conf }
+  with_adapters do
+    before { conf }
 
-  it 'creates a migration for a specific gateway' do
-    migration = ROM::SQL.migration do
-      change do
-        create_table :dragons do
-          primary_key :id
-          column :name, String
+    it 'creates a migration for a specific gateway' do
+      migration = ROM::SQL.migration(container) do
+        change do
+          create_table :dragons do
+            primary_key :id
+            column :name, String
+          end
         end
       end
+
+      migration.apply(conn, :up)
+
+      expect(conn.table_exists?(:dragons)).to be(true)
     end
+  end
 
-    migration.apply(conn, :up)
+  context 'with non-default gateway' do
+    with_adapters(:postgres) do
+      let(:conf) do
+        ROM::Configuration.new(
+          default: [:sql, conn, inferrable_relations: %i(schema_migrations)],
+          in_memory: [:sql, DB_URIS[:sqlite], inferrable_relations: %i(schema_migrations)]
+        )
+      end
 
-    expect(conn.table_exists?(:dragons)).to be(true)
+      let(:in_memory_connection) { container.gateways[:in_memory].connection }
+
+      it 'creates a migration for a specific gateway' do
+        in_memory_migration = ROM::SQL.migration(container, :in_memory) do
+          change do
+            create_table :turtles do
+              primary_key :id
+              column :name, String
+            end
+          end
+        end
+
+        in_memory_migration.apply(in_memory_connection, :up)
+
+        expect(in_memory_connection.table_exists?(:dragons)).to be(false)
+        expect(in_memory_connection.table_exists?(:turtles)).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
I actually tried several solutions and came up with a transient global variable
used for running migrations exclusively. Other options would much more invasive
from my POV, i.e. mokey-patching Sequel or the global "main" object / top-level
binding. I beleive we'll be able to get rid of this gvar in a while because we'll
have to take migrations loading under our control for things like
auto-migrations and alike.

`current_gateway` is not thread-safe but I don't think we care, running
migrations in threads won't make anyone happy