### PR TITLE
Support for row-level locks

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -7,6 +7,22 @@ module ROM
       #
       # @api public
       module Reading
+        # Row-level lock modes
+        ROW_LOCK_MODES = Hash.new(update: 'FOR UPDATE'.freeze).update(
+          # https://www.postgresql.org/docs/current/static/sql-select.html#SQL-FOR-UPDATE-SHARE
+          postgres: {
+            update: 'FOR UPDATE'.freeze,
+            no_key_update: 'FOR NO KEY UPDATE'.freeze,
+            share: 'FOR SHARE'.freeze,
+            key_share: 'FOR KEY SHARE'.freeze
+          },
+          # https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
+          mysql: {
+            update: 'FOR UPDATE'.freeze,
+            share: 'LOCK IN SHARE MODE'.freeze
+          }
+        ).freeze
+
         # Fetch a tuple identified by the pk
         #
         # @example
@@ -810,7 +826,64 @@ module ROM
           new(dataset.db[sql], schema: schema.empty)
         end
 
+        # Lock rows with in the specified mode. Check out ROW_LOCK_MODES for the
+        # list of supported modes, keep in mind available lock modes heavily depend on
+        # the database type+version you're running on.
+        #
+        # @overload lock(options)
+        #   @option options [Symbol] :mode Lock mode
+        #   @option options [Boolean,Integer] :wait Controls the (NO)WAIT part
+        #   @option options [Boolean] :skip_locked Skip locked rows
+        #
+        #   @return [SQL::Relation]
+        #
+        # @overload lock(options, &block)
+        #   Runs the block inside a transaction. The relation will be materialized
+        #   and passed inside the block so that the lock will be acquired right before
+        #   the block gets executed.
+        #
+        #   @param [Hash] options The same options as for the version without a block
+        #   @yieldparam relation [Array]
+        #
+        # @api public
+        def lock(options = EMPTY_HASH, &block)
+          clause = lock_clause(options)
+
+          if block
+            dataset.db.transaction do
+              block.call(dataset.lock_style(clause).to_a)
+            end
+          else
+            new(dataset.lock_style(clause))
+          end
+        end
+
         private
+
+        # Build a locking clause
+        #
+        # @api private
+        def lock_clause(mode: :update, skip_locked: false, of: nil, wait: nil)
+          locks = ROW_LOCK_MODES.fetch(dataset.db.database_type) { ROW_LOCK_MODES[:default] }
+
+          stmt = locks[mode].dup
+          stmt << ' OF ' << Array(of).join(', ') if of
+
+          if skip_locked
+            raise ArgumentError, "SKIP LOCKED cannot be used with (NO)WAIT clause" if !wait.nil?
+
+            stmt << ' SKIP LOCKED'
+          else
+            case wait
+            when Integer
+              stmt << ' WAIT ' << wait.to_s
+            when false
+              stmt << ' NOWAIT'
+            else
+              stmt
+            end
+          end
+        end
 
         # Apply input types to condition values
         #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,7 +77,7 @@ end
 
 def with_adapters(*args, &block)
   reset_adapter = Hash[*ADAPTERS.flat_map { |a| [a, false] }]
-  adapters = args.empty? || args[0] == :all ? ADAPTERS : args
+  adapters = args.empty? || args[0] == :all ? ADAPTERS : (args & ADAPTERS)
 
   adapters.each do |adapter|
     context("with #{adapter}", **reset_adapter, adapter => true, &block)

--- a/spec/unit/relation/lock_spec.rb
+++ b/spec/unit/relation/lock_spec.rb
@@ -1,0 +1,95 @@
+require 'thread'
+
+RSpec.describe ROM::Relation, '#lock' do
+  include_context 'users and tasks'
+
+  subject(:relation) { users }
+
+  def lock_style(relation)
+    relation.dataset.opts.fetch(:lock)
+  end
+
+  context 'with hitting the database' do
+    let(:mutex) { Mutex.new }
+    let(:semaphore) { ConditionVariable.new }
+
+    let(:timeout) { 0.2 }
+
+    let!(:start) { Time.now }
+
+    def elapsed_time
+      Time.now.to_f - start.to_f
+    end
+
+    with_adapters :postgres, :mysql, :oracle do
+      it 'locks rows for update' do
+        Thread.new do
+          mutex.synchronize do
+            relation.lock do |rel|
+              sleep timeout
+
+              semaphore.signal
+            end
+          end
+        end
+
+        mutex.synchronize do
+          semaphore.wait(mutex)
+
+          relation.lock
+
+          expect(elapsed_time).to be > timeout
+        end
+      end
+    end
+  end
+
+  with_adapters :postgres, :mysql, :oracle do
+    it 'selects rows for update' do
+      expect(lock_style(relation.lock)).to eql('FOR UPDATE')
+    end
+
+    it 'locks without wait' do
+      expect(lock_style(relation.lock(wait: false))).to eql('FOR UPDATE NOWAIT')
+    end
+
+    it 'skips locked rows' do
+      expect(lock_style(relation.lock(skip_locked: true))).to eql('FOR UPDATE SKIP LOCKED')
+    end
+
+    it 'raises an exception on attempt to use NOWAIT/WAIT with SKIP LOCKED' do
+      expect { relation.lock(wait: false, skip_locked: true) }
+        .to raise_error(ArgumentError, /cannot be used/)
+    end
+  end
+
+  with_adapters :postgres do
+    it 'locks with UPDATE OF' do
+      expect(lock_style(relation.lock(of: :users))).to eql('FOR UPDATE OF users')
+    end
+
+    it 'locks rows in different modes' do
+      expect(lock_style(relation.lock(mode: :update))).to eql('FOR UPDATE')
+      expect(lock_style(relation.lock(mode: :no_key_update))).to eql('FOR NO KEY UPDATE')
+      expect(lock_style(relation.lock(mode: :share))).to eql('FOR SHARE')
+      expect(lock_style(relation.lock(mode: :key_share))).to eql('FOR KEY SHARE')
+    end
+  end
+
+  with_adapters :mysql do
+    it 'locks rows in the SHARE mode' do
+      expect(lock_style(relation.lock(mode: :share))).to eql('LOCK IN SHARE MODE')
+    end
+  end
+
+  with_adapters :oracle do
+    it 'locks with timeout' do
+      expect(lock_style(relation.lock(wait: 10))).to eql('FOR UPDATE WAIT 10')
+    end
+
+    it 'locks with UPDATE OF' do
+      expect(lock_style(relation.lock(of: :name))).to eql('FOR UPDATE OF name')
+      expect(lock_style(relation.lock(of: %i(id name)))).to eql('FOR UPDATE OF id, name')
+    end
+  end
+end


### PR DESCRIPTION
This at least adds support for PosqtreSQL, MySQL, and Oracle. SQLite doesn't have row-level locks.

I will try it in my app first, but it's more or less complete.