### PR TITLE
Adding API for auto-migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rom', git: 'https://github.com/rom-rb/rom', branch: 'master' do
 end
 
 group :test do
-  gem 'byebug', platforms: :mri
+  gem 'pry-byebug', platforms: :mri
   gem 'pry', platforms: %i(jruby rbx)
   gem 'dry-types', git: 'https://github.com/dry-rb/dry-types.git'
   gem 'dry-struct'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ end
 group :test do
   gem 'pry-byebug', platforms: :mri
   gem 'pry', platforms: %i(jruby rbx)
-  gem 'dry-types', git: 'https://github.com/dry-rb/dry-types.git'
   gem 'dry-struct'
   gem 'activesupport', '~> 5.0'
   gem 'codeclimate-test-reporter', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 group :test do
   gem 'byebug', platforms: :mri
   gem 'pry', platforms: %i(jruby rbx)
+  gem 'dry-types', git: 'https://github.com/dry-rb/dry-types.git'
   gem 'dry-struct'
   gem 'activesupport', '~> 5.0'
   gem 'codeclimate-test-reporter', require: false

--- a/lib/rom/plugins/relation/sql/auto_restrictions.rb
+++ b/lib/rom/plugins/relation/sql/auto_restrictions.rb
@@ -39,7 +39,7 @@ module ROM
           def self.restriction_methods(schema)
             mod = Module.new
 
-            indexed_attrs = schema.select { |attr| attr.meta[:index] }
+            indexed_attrs = schema.select(&:indexed?)
 
             methods = indexed_attrs.map do |attr|
               meth_name = :"by_#{attr.name}"

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -14,6 +14,7 @@ module ROM
     class Attribute < ROM::Schema::Attribute
       OPERATORS = %i[>= <= > <].freeze
       NONSTANDARD_EQUALITY_VALUES = [true, false, nil].freeze
+      INDEXED = Set.new([true]).freeze
 
       # Error raised when an attribute cannot be qualified
       QualifyError = Class.new(StandardError)
@@ -282,6 +283,27 @@ module ROM
           else
             Sequel[name]
           end
+      end
+
+      # @api public
+      def indexed?
+        !indexes.empty?
+      end
+
+      # @api public
+      def indexes
+        if meta[:index] == true
+          INDEXED
+        else
+          meta[:index] || EMPTY_SET
+        end
+      end
+
+      # @api private
+      def meta_ast
+        meta = super
+        meta[:index] = indexes if indexed?
+        meta
       end
 
       private

--- a/lib/rom/sql/errors.rb
+++ b/lib/rom/sql/errors.rb
@@ -12,6 +12,8 @@ module ROM
     CheckConstraintError      = Class.new(ConstraintError)
     UnknownDBTypeError        = Class.new(StandardError)
     MissingPrimaryKeyError    = Class.new(StandardError)
+    MigrationError            = Class.new(StandardError)
+    UnsupportedConversion     = Class.new(MigrationError)
 
     ERROR_MAP = {
       Sequel::DatabaseError => DatabaseError,

--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -193,6 +193,15 @@ module ROM
         @schema ||= connection.tables
       end
 
+      # Underlying database type
+      #
+      # @return [Symbol]
+      #
+      # @api public
+      def database_type
+        @database_type ||= connection.database_type.to_sym
+      end
+
       private
 
       # Connect to database or reuse established connection instance
@@ -213,13 +222,11 @@ module ROM
       #
       # @api private
       def load_extensions(exts)
-        db_type = connection.database_type.to_sym
-
-        if ROM::SQL.available_extension?(db_type)
-          ROM::SQL.load_extensions(db_type)
+        if ROM::SQL.available_extension?(database_type)
+          ROM::SQL.load_extensions(database_type)
         end
 
-        extensions = (CONNECTION_EXTENSIONS.fetch(db_type, EMPTY_ARRAY) + exts).uniq
+        extensions = (CONNECTION_EXTENSIONS.fetch(database_type, EMPTY_ARRAY) + exts).uniq
         connection.extension(*extensions)
 
         # this will be default in Sequel 5.0.0 and since we don't rely

--- a/lib/rom/sql/migration.rb
+++ b/lib/rom/sql/migration.rb
@@ -140,7 +140,7 @@ module ROM
       # @api public
       def auto_migrate!(container)
         name = container.gateways.find { |_, gw| gw.equal?(self) }[0]
-        migrator.diff(container, name).reject(&:empty?).each { |diff| diff.apply(self) }
+        migrator.auto_migrate!(container, name)
       end
     end
   end

--- a/lib/rom/sql/migration.rb
+++ b/lib/rom/sql/migration.rb
@@ -140,7 +140,7 @@ module ROM
       # @api public
       def auto_migrate!(container)
         name = container.gateways.find { |_, gw| gw.equal?(self) }[0]
-        migrator.diff(container, name).each { |diff| diff.apply(self) }
+        migrator.diff(container, name).reject(&:empty?).each { |diff| diff.apply(self) }
       end
     end
   end

--- a/lib/rom/sql/migration.rb
+++ b/lib/rom/sql/migration.rb
@@ -138,9 +138,12 @@ module ROM
       end
 
       # @api public
-      def auto_migrate!(container)
-        name = container.gateways.find { |_, gw| gw.equal?(self) }[0]
-        migrator.auto_migrate!(container, name)
+      def auto_migrate!(conf)
+        schemas = conf.relation_classes(self).map do |klass|
+          klass.schema || klass.schema_proc.call.finalize_attributes!(gateway: self)
+        end
+
+        migrator.auto_migrate!(self, schemas)
       end
     end
   end

--- a/lib/rom/sql/migration.rb
+++ b/lib/rom/sql/migration.rb
@@ -1,4 +1,5 @@
 require 'rom/sql/migration/migrator'
+require 'rom/sql/migration/schema_diff'
 
 module ROM
   module SQL
@@ -134,6 +135,12 @@ module ROM
         ROM::SQL.with_gateway(self) {
           migrator.run(options)
         }
+      end
+
+      # @api public
+      def auto_migrate!(container)
+        name = container.gateways.find { |_, gw| gw.equal?(self) }[0]
+        migrator.diff(container, name).each { |diff| diff.apply(self) }
       end
     end
   end

--- a/lib/rom/sql/migration/inline_runner.rb
+++ b/lib/rom/sql/migration/inline_runner.rb
@@ -29,13 +29,11 @@ module ROM
 
           def create_table(diff)
             gateway.create_table(diff.table_name) do
-              diff.schema.to_a.each do |attribute|
+              diff.attributes.each do |attribute|
                 if attribute.primary_key?
                   primary_key attribute.name
                 else
-                  unwrapped = attribute.optional? ? attribute.right : attribute
-                  column attribute.name, unwrapped.primitive, null: attribute.optional?
-
+                  column attribute.name, attribute.type, null: attribute.null?
                   index attribute.name if attribute.indexed?
                 end
               end

--- a/lib/rom/sql/migration/inline_runner.rb
+++ b/lib/rom/sql/migration/inline_runner.rb
@@ -50,6 +50,13 @@ module ROM
                 when SchemaDiff::AttributeRemoved
                   drop_column attribute.name
                 when SchemaDiff::AttributeChanged
+                  if attribute.type_changed?
+                    from, to = attribute.to_a.map(&attribute.method(:unwrap))
+                    raise UnsupportedConversion.new(
+                            "Don't know how to convert #{ from.inspect } to #{ to.inspect }"
+                          )
+                  end
+
                   if attribute.index_changed?
                     if attribute.indexed?
                       add_index attribute.name

--- a/lib/rom/sql/migration/inline_runner.rb
+++ b/lib/rom/sql/migration/inline_runner.rb
@@ -57,6 +57,8 @@ module ROM
               diff.changed.each do |name, (from, to)|
                 if !from.indexed? && to.indexed?
                   add_index name
+                elsif from.indexed? && !to.indexed?
+                  drop_index name
                 end
               end
             end

--- a/lib/rom/sql/migration/inline_runner.rb
+++ b/lib/rom/sql/migration/inline_runner.rb
@@ -50,8 +50,21 @@ module ROM
                 when SchemaDiff::AttributeRemoved
                   drop_column attribute.name
                 when SchemaDiff::AttributeChanged
-                  add_index attribute.name if attribute.index_added?
-                  drop_index attribute.name if attribute.index_removed?
+                  if attribute.index_changed?
+                    if attribute.indexed?
+                      add_index attribute.name
+                    else
+                      drop_index attribute.name
+                    end
+                  end
+
+                  if attribute.nullability_changed?
+                    if attribute.null?
+                      set_column_allow_null attribute.name
+                    else
+                      set_column_not_null attribute.name
+                    end
+                  end
                 end
               end
             end

--- a/lib/rom/sql/migration/inline_runner.rb
+++ b/lib/rom/sql/migration/inline_runner.rb
@@ -1,0 +1,68 @@
+module ROM
+  module SQL
+    module Migration
+      class Migrator
+        # @api private
+        class InlineRunner
+          attr_reader :gateway
+
+          def initialize(gateway)
+            @gateway = gateway
+          end
+
+          def call(changes)
+            changes.each do |diff|
+              apply(diff)
+            end
+          end
+
+          def apply(diff)
+            case diff
+            when SchemaDiff::TableCreated
+              create_table(diff)
+            when SchemaDiff::TableAltered
+              alter_table(diff)
+            else
+              raise NotImplementedError
+            end
+          end
+
+          def create_table(diff)
+            gateway.create_table(diff.table_name) do
+              diff.schema.to_a.each do |attribute|
+                if attribute.primary_key?
+                  primary_key attribute.name
+                else
+                  unwrapped = attribute.optional? ? attribute.right : attribute
+                  column attribute.name, unwrapped.primitive, null: attribute.optional?
+
+                  index attribute.name if attribute.indexed?
+                end
+              end
+            end
+          end
+
+          def alter_table(diff)
+            gateway.connection.alter_table(diff.table_name) do
+              diff.added.each do |name, attribute|
+                unwrapped = attribute.optional? ? attribute.right : attribute
+                add_column name, unwrapped.primitive, null: attribute.optional?
+                add_index name if attribute.indexed?
+              end
+
+              diff.removed.each do |name, _|
+                drop_column name
+              end
+
+              diff.changed.each do |name, (from, to)|
+                if !from.indexed? && to.indexed?
+                  add_index name
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -41,6 +41,8 @@ module ROM
                 else
                   unwrapped = attribute.optional? ? attribute.right : attribute
                   column attribute.name, unwrapped.primitive, null: attribute.optional?
+
+                  index attribute.name if attribute.indexed?
                 end
               end
             end
@@ -51,6 +53,7 @@ module ROM
               diff.added_attributes.each do |attribute|
                 unwrapped = attribute.optional? ? attribute.right : attribute
                 add_column attribute.name, unwrapped.primitive, null: attribute.optional?
+                add_index attribute.name if attribute.indexed?
               end
 
               diff.removed_attributes.each do |attribute|

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -62,7 +62,7 @@ module ROM
 
           relations.map do |_, relation|
             target = relation.schema
-            current_atttributes, _ = target.inferrer.(relation.name.dataset, gateway)
+            current_atttributes, _ = relation.class.schema_inferrer.(relation.name, gateway)
             current = target.with(
               attributes: target.class.attributes(current_atttributes, target.options[:attr_class])
             )

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -63,7 +63,7 @@ module ROM
             attributes: target.class.attributes(current_atttributes, target.attr_class)
           )
 
-          SchemaDiff.compare(current, target)
+          SchemaDiff.new.(current, target)
         end
 
         def auto_migrate!(gateway, schemas)

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -9,6 +9,57 @@ module ROM
     module Migration
       # @api private
       class Migrator
+        class InlineRunner
+          attr_reader :gateway
+
+          def initialize(gateway)
+            @gateway = gateway
+          end
+
+          def call(changes)
+            changes.each do |diff|
+              apply(diff)
+            end
+          end
+
+          def apply(diff)
+            case diff
+            when SchemaDiff::TableCreated
+              create_table(diff)
+            when SchemaDiff::TableAltered
+              alter_table(diff)
+            else
+              raise NotImplementedError
+            end
+          end
+
+          def create_table(diff)
+            gateway.create_table(diff.table_name) do
+              diff.schema.to_a.each do |attribute|
+                if attribute.primary_key?
+                  primary_key attribute.name
+                else
+                  unwrapped = attribute.optional? ? attribute.right : attribute
+                  column attribute.name, unwrapped.primitive, null: attribute.optional?
+                end
+              end
+            end
+          end
+
+          def alter_table(diff)
+            gateway.connection.alter_table(diff.table_name) do
+              diff.new_attributes.each do |attribute|
+                unwrapped = attribute.optional? ? attribute.right : attribute
+                add_column attribute.name, unwrapped.primitive, null: attribute.optional?
+              end
+
+              diff.removed_attributes.each do |attribute|
+                drop_column attribute.name
+              end
+            end
+          end
+        end
+
         extend Initializer
 
         DEFAULT_PATH = 'db/migrate'.freeze
@@ -69,6 +120,12 @@ module ROM
 
             SchemaDiff.compare(current, target)
           end
+        end
+
+        def auto_migrate!(container, gateway)
+          runner = InlineRunner.new(container.gateways[gateway])
+          changes = diff(container, gateway).reject(&:empty?)
+          runner.call(changes)
         end
       end
     end

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -110,7 +110,7 @@ module ROM
         def diff(gateway, inferrer, target)
           current_atttributes, _ = inferrer.(target.name, gateway)
           current = target.with(
-            attributes: target.class.attributes(current_atttributes, target.options[:attr_class])
+            attributes: target.class.attributes(current_atttributes, target.attr_class)
           )
 
           SchemaDiff.compare(current, target)

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -15,16 +15,34 @@ module ROM
               new_attributes: new_attributes,
               removed_attributes: removed_attributes
             )
+          else
+            Empty.new(target)
           end
         end
 
-        class TableCreated
+        class Diff
           attr_reader :schema
 
           def initialize(schema)
             @schema = schema
           end
 
+          def empty?
+            false
+          end
+
+          def apply(gateway)
+            raise NotImplementedError
+          end
+        end
+
+        class Empty < Diff
+          def empty?
+            true
+          end
+        end
+
+        class TableCreated < Diff
           def apply(gateway)
             attributes = schema.to_a
 
@@ -41,11 +59,12 @@ module ROM
           end
         end
 
-        class TableAltered
-          attr_reader :schema, :new_attributes, :removed_attributes
+        class TableAltered < Diff
+          attr_reader :new_attributes, :removed_attributes
 
           def initialize(schema, new_attributes: EMPTY_ARRAY, removed_attributes: EMPTY_ARRAY)
-            @schema = schema
+            super(schema)
+
             @new_attributes = new_attributes
             @removed_attributes = removed_attributes
           end

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -4,15 +4,15 @@ module ROM
       class SchemaDiff
         def self.compare(current, target)
           current_attrs, target_attrs = current.to_a, target.to_a
-          new_attributes = target_attrs - current_attrs
+          added_attributes = target_attrs - current_attrs
           removed_attributes = current_attrs - target_attrs
 
           if current_attrs.empty?
             TableCreated.new(target)
-          elsif !new_attributes.empty? || !removed_attributes.empty?
+          elsif !added_attributes.empty? || !removed_attributes.empty?
             TableAltered.new(
               target,
-              new_attributes: new_attributes,
+              added_attributes: added_attributes,
               removed_attributes: removed_attributes
             )
           else
@@ -46,12 +46,12 @@ module ROM
         end
 
         class TableAltered < Diff
-          attr_reader :new_attributes, :removed_attributes
+          attr_reader :added_attributes, :removed_attributes
 
-          def initialize(schema, new_attributes: EMPTY_ARRAY, removed_attributes: EMPTY_ARRAY)
+          def initialize(schema, added_attributes: EMPTY_ARRAY, removed_attributes: EMPTY_ARRAY)
             super(schema)
 
-            @new_attributes = new_attributes
+            @added_attributes = added_attributes
             @removed_attributes = removed_attributes
           end
         end

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -27,6 +27,13 @@ module ROM
 
         class TableCreated < TableDiff
           alias_method :schema, :target_schema
+          attr_reader :attributes
+
+          def initialize(attributes:, **rest)
+            super(rest)
+
+            @attributes = attributes
+          end
         end
 
         class TableAltered < TableDiff
@@ -64,6 +71,14 @@ module ROM
           def null?
             attr.optional?
           end
+
+          def indexed?
+            attr.indexed?
+          end
+
+          def primary_key?
+            attr.primary_key?
+          end
         end
 
         class AttributeRemoved < AttributeDiff
@@ -94,7 +109,7 @@ module ROM
 
         def call(current, target)
           if current.empty?
-            TableCreated.new(target_schema: target)
+            TableCreated.new(target_schema: target, attributes: target.map { |attr| AttributeAdded.new(attr) })
           else
             attribute_changes = compare_attributes(current.to_h, target.to_h)
 

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -2,35 +2,7 @@ module ROM
   module SQL
     module Migration
       class SchemaDiff
-        def self.compare(current, target)
-          if current.empty?
-            TableCreated.new(target_schema: target)
-          else
-            current_attrs, target_attrs = current.to_h, target.to_h
-
-            changed_attributes = target_attrs.select { |name, attr|
-              current_attrs.key?(name) && current_attrs[name] != attr
-            }.map { |name, target_attr|
-              [name, [current_attrs[name], target_attr]]
-            }.to_h
-            added_attributes = target_attrs.select { |name, _| !current_attrs.key?(name) }
-            removed_attributes = current_attrs.select { |name, _| !target_attrs.key?(name) }
-
-            if [changed_attributes, added_attributes, removed_attributes].all?(&:empty?)
-              Empty.new(current_schema: current, target_schema: target)
-            else
-              TableAltered.new(
-                current_schema: current,
-                target_schema: target,
-                added: added_attributes,
-                removed: removed_attributes,
-                changed: changed_attributes
-              )
-            end
-          end
-        end
-
-        class Diff
+        class TableDiff
           attr_reader :current_schema, :target_schema
 
           def initialize(current_schema: nil, target_schema: nil)
@@ -47,26 +19,109 @@ module ROM
           end
         end
 
-        class Empty < Diff
+        class Empty < TableDiff
           def empty?
             true
           end
         end
 
-        class TableCreated < Diff
+        class TableCreated < TableDiff
           alias_method :schema, :target_schema
         end
 
-        class TableAltered < Diff
-          attr_reader :added, :changed, :removed
+        class TableAltered < TableDiff
+          attr_reader :attribute_changes
 
-          def initialize(added: EMPTY_HASH, removed: EMPTY_HASH, changed: EMPTY_HASH, **rest)
+          def initialize(attribute_changes: EMPTY_ARRAY, **rest)
             super(rest)
 
-            @added = added
-            @removed = removed
-            @changed = changed
+            @attribute_changes = attribute_changes
           end
+        end
+
+        class AttributeDiff
+          attr_reader :attr
+
+          def initialize(attr)
+            @attr = attr
+          end
+
+          def name
+            attr.name
+          end
+        end
+
+        class AttributeAdded < AttributeDiff
+          def indexed?
+            attr.indexed?
+          end
+
+          def type
+            unwrapped = attr.optional? ? attr.right : attr
+            unwrapped.primitive
+          end
+
+          def null?
+            attr.optional?
+          end
+        end
+
+        class AttributeRemoved < AttributeDiff
+        end
+
+        class AttributeChanged < AttributeDiff
+          attr_reader :current
+          alias_method :target, :attr
+
+          def initialize(current, target)
+            super(target)
+
+            @current = current
+          end
+
+          def to_a
+            [current, target]
+          end
+
+          def index_added?
+            !current.indexed? && target.indexed?
+          end
+
+          def index_removed?
+            current.indexed? && !target.indexed?
+          end
+        end
+
+        def call(current, target)
+          if current.empty?
+            TableCreated.new(target_schema: target)
+          else
+            attribute_changes = compare_attributes(current.to_h, target.to_h)
+
+            if attribute_changes.empty?
+              Empty.new(current_schema: current, target_schema: target)
+            else
+              TableAltered.new(
+                current_schema: current,
+                target_schema: target,
+                attribute_changes: attribute_changes
+              )
+            end
+          end
+        end
+
+        def compare_attributes(current, target)
+          changed_attributes = target.select { |name, attr|
+            current.key?(name) && current[name] != attr
+          }.map { |name, target_attr|
+            [name, [current[name], target_attr]]
+          }.to_h
+          added_attributes = target.select { |name, _| !current.key?(name) }
+          removed_attributes = current.select { |name, _| !target.key?(name) }
+
+          removed_attributes.values.map { |attr| AttributeRemoved.new(attr) } +
+            added_attributes.values.map { |attr| AttributeAdded.new(attr) } +
+            changed_attributes.values.map { |attrs| AttributeChanged.new(*attrs) }
         end
       end
     end

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -68,12 +68,15 @@ module ROM
           def primary_key?
             attr.primary_key?
           end
+
+          def unwrap(type)
+            type.optional? ? SQL::Attribute[type.right].meta(type.meta) : type
+          end
         end
 
         class AttributeAdded < AttributeDiff
           def type
-            unwrapped = attr.optional? ? attr.right : attr
-            unwrapped.primitive
+            unwrap(attr).primitive
           end
         end
 
@@ -100,6 +103,10 @@ module ROM
 
           def nullability_changed?
             current.optional? ^ target.optional?
+          end
+
+          def type_changed?
+            unwrap(current).meta(index: Set.new) != unwrap(target).meta(index: Set.new)
           end
         end
 

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -56,17 +56,6 @@ module ROM
           def name
             attr.name
           end
-        end
-
-        class AttributeAdded < AttributeDiff
-          def indexed?
-            attr.indexed?
-          end
-
-          def type
-            unwrapped = attr.optional? ? attr.right : attr
-            unwrapped.primitive
-          end
 
           def null?
             attr.optional?
@@ -78,6 +67,13 @@ module ROM
 
           def primary_key?
             attr.primary_key?
+          end
+        end
+
+        class AttributeAdded < AttributeDiff
+          def type
+            unwrapped = attr.optional? ? attr.right : attr
+            unwrapped.primitive
           end
         end
 
@@ -98,12 +94,12 @@ module ROM
             [current, target]
           end
 
-          def index_added?
-            !current.indexed? && target.indexed?
+          def index_changed?
+            current.indexed? ^ target.indexed?
           end
 
-          def index_removed?
-            current.indexed? && !target.indexed?
+          def nullability_changed?
+            current.optional? ^ target.optional?
           end
         end
 

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -1,0 +1,40 @@
+module ROM
+  module SQL
+    module Migration
+      class SchemaDiff
+        def self.compare(current, target)
+          current_attrs, target_attrs = current.to_a, target.to_a
+          new_attributes = target_attrs - current_attrs
+
+          if current_attrs.empty?
+            TableAdded.new(target)
+          else
+            raise NotImplementedError, 'Only create_table available'
+          end
+        end
+
+        class TableAdded
+          attr_reader :schema
+
+          def initialize(schema)
+            @schema = schema
+          end
+
+          def apply(gateway)
+            attributes = schema.to_a
+
+            gateway.create_table(schema.name.dataset) do
+              attributes.each do |attribute|
+                if attribute.primary_key?
+                  primary_key attribute.name
+                else
+                  column attribute.name, attribute.type.primitive, null: false
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -31,8 +31,8 @@ module ROM
             false
           end
 
-          def apply(gateway)
-            raise NotImplementedError
+          def table_name
+            schema.name.dataset
           end
         end
 
@@ -43,20 +43,6 @@ module ROM
         end
 
         class TableCreated < Diff
-          def apply(gateway)
-            attributes = schema.to_a
-
-            gateway.create_table(schema.name.dataset) do
-              attributes.each do |attribute|
-                if attribute.primary_key?
-                  primary_key attribute.name
-                else
-                  unwrapped = attribute.optional? ? attribute.right : attribute
-                  column attribute.name, unwrapped.primitive, null: attribute.optional?
-                end
-              end
-            end
-          end
         end
 
         class TableAltered < Diff
@@ -67,22 +53,6 @@ module ROM
 
             @new_attributes = new_attributes
             @removed_attributes = removed_attributes
-          end
-
-          def apply(gateway)
-            new_attributes = self.new_attributes
-            removed_attributes = self.removed_attributes
-
-            gateway.connection.alter_table(schema.name.dataset) do
-              new_attributes.each do |attribute|
-                unwrapped = attribute.optional? ? attribute.right : attribute
-                add_column attribute.name, unwrapped.primitive, null: attribute.optional?
-              end
-
-              removed_attributes.each do |attribute|
-                drop_column attribute.name
-              end
-            end
           end
         end
       end

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -28,7 +28,8 @@ module ROM
                 if attribute.primary_key?
                   primary_key attribute.name
                 else
-                  column attribute.name, attribute.type.primitive, null: false
+                  unwrapped = attribute.optional? ? attribute.right : attribute
+                  column attribute.name, unwrapped.primitive, null: attribute.optional?
                 end
               end
             end
@@ -48,7 +49,8 @@ module ROM
 
             gateway.connection.alter_table(schema.name.dataset) do
               attributes.each do |attribute|
-                add_column attribute.name, attribute.type.primitive, null: false
+                unwrapped = attribute.optional? ? attribute.right : attribute
+                add_column attribute.name, unwrapped.primitive, null: attribute.optional?
               end
             end
           end

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -24,13 +24,8 @@ module ROM
       schema_class SQL::Schema
       schema_attr_class SQL::Attribute
       schema_inferrer -> (name, gateway) do
-        inferrer_for_db = ROM::SQL::Schema::Inferrer.get(gateway.connection.database_type.to_sym)
-        begin
-          inferrer_for_db.new.call(name, gateway)
-        rescue Sequel::Error => e
-          inferrer_for_db.on_error(name, e)
-          ROM::Schema::DEFAULT_INFERRER.()
-        end
+        inferrer_for_db = ROM::SQL::Schema::Inferrer.get(gateway.database_type).new
+        inferrer_for_db.(name, gateway)
       end
       wrap_class SQL::Wrap
 

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -24,7 +24,7 @@ module ROM
       schema_class SQL::Schema
       schema_attr_class SQL::Attribute
       schema_inferrer -> (name, gateway) do
-        inferrer_for_db = ROM::SQL::Schema::Inferrer.get(gateway.database_type).new
+        inferrer_for_db = ROM::SQL::Schema::Inferrer.get(gateway.database_type).new.suppress_errors
         inferrer_for_db.(name, gateway)
       end
       wrap_class SQL::Wrap

--- a/spec/integration/auto_migrations/create_table_spec.rb
+++ b/spec/integration/auto_migrations/create_table_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe ROM::SQL::Gateway, :postgres do
+  include_context 'database setup'
+
+  def inferred_schema(rel_name)
+    conf = ROM::Configuration.new(:sql, conn) do |conf|
+      conf.relation(rel_name) do
+        schema(infer: true)
+      end
+    end
+
+    container = ROM.container(conf)
+    container.relation(rel_name).schema
+  end
+
+  describe 'create table' do
+    subject(:gateway) { container.gateways[:default] }
+
+    it 'creates table from relation' do
+      conf.relation(:users) do
+        schema do
+          attribute :id,    ROM::SQL::Types::Serial
+          attribute :name,  ROM::SQL::Types::String
+        end
+      end
+
+      gateway.auto_migrate!(container)
+
+      expect(inferred_schema(:users).to_ast)
+        .to eql(
+              [:schema,
+               [ROM::Relation::Name[:users],
+                [[:attribute,
+                  [:id,
+                   [:definition, [Integer, {}]],
+                   primary_key: true, source: :users]],
+                 [:attribute, [:name, [:definition, [String, {}]], source: :users]]]]]
+            )
+    end
+  end
+end

--- a/spec/integration/auto_migrations/errors_spec.rb
+++ b/spec/integration/auto_migrations/errors_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ROM::SQL::Gateway, :postgres do
+  include_context 'database setup'
+
+  subject(:gateway) { container.gateways[:default] }
+
+  before do
+    conn.drop_table?(:users)
+  end
+
+  describe 'unsupported conversions' do
+    before do
+      conf.relation(:users) do
+        schema do
+          attribute :id,    ROM::SQL::Types::Serial
+          attribute :name,  ROM::SQL::Types::String
+        end
+      end
+    end
+
+    it 'raises an error' do
+      conn.create_table :users do
+        primary_key :id
+        column :name, Integer, null: false
+      end
+
+      expect {
+        gateway.auto_migrate!(conf)
+      }.to raise_error(ROM::SQL::UnsupportedConversion, /Don't know how to convert/)
+    end
+  end
+end

--- a/spec/integration/auto_migrations/indexes_spec.rb
+++ b/spec/integration/auto_migrations/indexes_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe ROM::SQL::Gateway, :postgres do
+  include_context 'database setup'
+
+  before do
+    conn.drop_table?(:users)
+  end
+
+  to_attr = ROM::SQL::Attribute.method(:new)
+
+  let(:table_name) { :users }
+
+  subject(:gateway) { container.gateways[:default] }
+
+  let(:inferrer) { ROM::SQL::Schema::Inferrer.get(gateway.database_type).new }
+
+  let(:attributes) { inferrer.(ROM::Relation::Name[table_name], gateway)[0].map(&to_attr) }
+
+  describe 'create table' do
+    describe 'one-column indexes' do
+      before do
+        conf.relation(:users) do
+          schema do
+            attribute :id,    ROM::SQL::Types::Serial
+            attribute :name,  ROM::SQL::Types::String.meta(index: true)
+          end
+        end
+      end
+
+      it 'creates ordinary b-tree indexes' do
+        gateway.auto_migrate!(conf)
+
+        expect(attributes.map(&:to_ast))
+          .to eql([
+                    [:attribute,
+                     [:id,
+                      [:definition, [Integer, {}]],
+                      primary_key: true, source: :users]],
+                    [:attribute,
+                     [:name,
+                      [:definition, [String, {}]],
+                      source: :users, index: %i(users_name_index).to_set]],
+                  ])
+      end
+    end
+  end
+
+  describe 'alter table' do
+    describe 'one-column indexes' do
+      before do
+        conf.relation(:users) do
+          schema do
+            attribute :id,    ROM::SQL::Types::Serial
+            attribute :name,  ROM::SQL::Types::String.meta(index: true)
+          end
+        end
+      end
+
+      it 'adds indexed column' do
+        conn.create_table :users do
+          primary_key :id
+        end
+
+        gateway.auto_migrate!(conf)
+
+        expect(attributes[1].name).to eql(:name)
+        expect(attributes[1]).to be_indexed
+      end
+    end
+  end
+end

--- a/spec/integration/auto_migrations/indexes_spec.rb
+++ b/spec/integration/auto_migrations/indexes_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
         expect(attributes[1].name).to eql(:name)
         expect(attributes[1]).to be_indexed
       end
+
+      it 'adds index to existing column' do
+        conn.create_table :users do
+          primary_key :id
+          column :name, String
+        end
+
+        gateway.auto_migrate!(conf)
+
+        expect(attributes[1].name).to eql(:name)
+        expect(attributes[1]).to be_indexed
+      end
     end
   end
 end

--- a/spec/integration/auto_migrations/managing_columns_spec.rb
+++ b/spec/integration/auto_migrations/managing_columns_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
         schema do
           attribute :id,    ROM::SQL::Types::Serial
           attribute :name,  ROM::SQL::Types::String
+          attribute :email, ROM::SQL::Types::String.optional
         end
       end
 
@@ -37,8 +38,17 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
                   [:id,
                    [:definition, [Integer, {}]],
                    primary_key: true, source: :users]],
-                 [:attribute, [:name, [:definition, [String, {}]], source: :users]]]]]
-            )
+                 [:attribute, [:name, [:definition, [String, {}]], source: :users]],
+                 [:attribute,
+                  [:email,
+                   [:sum,
+                    [[:constrained,
+                      [[:definition, [NilClass, {}]],
+                       [:predicate, [:type?, [[:type, NilClass], [:input, ROM::Undefined]]]],
+                       {}]],
+                     [:definition, [String, {}]],
+                     {}]],
+                   source: :users]]]]])
     end
   end
 
@@ -54,6 +64,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
         schema do
           attribute :id,    ROM::SQL::Types::Serial
           attribute :name,  ROM::SQL::Types::String
+          attribute :email, ROM::SQL::Types::String.optional
         end
       end
 
@@ -62,6 +73,19 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
       expect(inferred_schema(:users)[:name].to_ast)
         .to eql(
               [:attribute, [:name, [:definition, [String, {}]], source: :users]]
+            )
+      expect(inferred_schema(:users)[:email].to_ast)
+        .to eql(
+              [:attribute,
+               [:email,
+                [:sum,
+                 [[:constrained,
+                   [[:definition, [NilClass, {}]],
+                    [:predicate, [:type?, [[:type, NilClass], [:input, ROM::Undefined]]]],
+                    {}]],
+                  [:definition, [String, {}]],
+                  {}]],
+                source: :users]]
             )
     end
   end

--- a/spec/integration/auto_migrations/managing_columns_spec.rb
+++ b/spec/integration/auto_migrations/managing_columns_spec.rb
@@ -114,4 +114,40 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
       expect(attributes).to eql(current.to_a)
     end
   end
+
+  describe 'changing NOTNULL' do
+    describe 'adding' do
+      before do
+        conn.create_table :users do
+          primary_key :id
+          column :name, String
+          column :email, String
+        end
+      end
+
+      it 'adds the constraint' do
+        gateway.auto_migrate!(conf)
+
+        expect(attributes[1].name).to eql(:name)
+        expect(attributes[1]).not_to be_optional
+      end
+    end
+
+    describe 'removing' do
+      before do
+        conn.create_table :users do
+          primary_key :id
+          column :name, String, null: false
+          column :email, String, null: false
+        end
+      end
+
+      it 'removes the constraint' do
+        gateway.auto_migrate!(conf)
+
+        expect(attributes[2].name).to eql(:email)
+        expect(attributes[2]).to be_optional
+      end
+    end
+  end
 end

--- a/spec/integration/auto_migrations/managing_columns_spec.rb
+++ b/spec/integration/auto_migrations/managing_columns_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe ROM::SQL::Gateway, :postgres do
   include_context 'database setup'
 
+  before do
+    conn.drop_table?(:users)
+  end
+
+  subject(:gateway) { container.gateways[:default] }
+
   def inferred_schema(rel_name)
     conf = ROM::Configuration.new(:sql, conn) do |conf|
       conf.relation(rel_name) do
@@ -12,10 +18,8 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
     container.relation(rel_name).schema
   end
 
-  describe 'create table' do
-    subject(:gateway) { container.gateways[:default] }
-
-    it 'creates table from relation' do
+  describe 'create a table' do
+    it 'creates a table from a relation' do
       conf.relation(:users) do
         schema do
           attribute :id,    ROM::SQL::Types::Serial
@@ -34,6 +38,30 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
                    [:definition, [Integer, {}]],
                    primary_key: true, source: :users]],
                  [:attribute, [:name, [:definition, [String, {}]], source: :users]]]]]
+            )
+    end
+  end
+
+  describe 'adding columns' do
+    before do
+      conn.create_table :users do
+        primary_key :id
+      end
+    end
+
+    it 'adds columns to an existing table' do
+      conf.relation(:users) do
+        schema do
+          attribute :id,    ROM::SQL::Types::Serial
+          attribute :name,  ROM::SQL::Types::String
+        end
+      end
+
+      gateway.auto_migrate!(container)
+
+      expect(inferred_schema(:users)[:name].to_ast)
+        .to eql(
+              [:attribute, [:name, [:definition, [String, {}]], source: :users]]
             )
     end
   end

--- a/spec/integration/auto_migrations/managing_columns_spec.rb
+++ b/spec/integration/auto_migrations/managing_columns_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
                        {}]],
                      [:definition, [String, {}]],
                      {}]],
-                   source: :users]]]]])
+                   source: :users]]]]]
+            )
     end
   end
 

--- a/spec/integration/auto_migrations/managing_columns_spec.rb
+++ b/spec/integration/auto_migrations/managing_columns_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
 
   describe 'create a table' do
     it 'creates a table from a relation' do
-      gateway.auto_migrate!(container)
+      gateway.auto_migrate!(conf)
 
       expect(inferred_schema(:users).to_ast)
         .to eql(
@@ -62,7 +62,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
     end
 
     it 'adds columns to an existing table' do
-      gateway.auto_migrate!(container)
+      gateway.auto_migrate!(conf)
 
       expect(inferred_schema(:users)[:name].to_ast)
         .to eql(
@@ -95,7 +95,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
     end
 
     it 'removes columns from a table' do
-      gateway.auto_migrate!(container)
+      gateway.auto_migrate!(conf)
 
       expect(inferred_schema(:users).map(&:name)).to eql(%i(id name email))
     end
@@ -113,7 +113,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
     it 'leaves existing schema' do
       current = container.relation(:users).schema
 
-      gateway.auto_migrate!(container)
+      gateway.auto_migrate!(conf)
 
       expect(inferred_schema(:users)).to eql(current)
     end

--- a/spec/integration/auto_migrations/managing_columns_spec.rb
+++ b/spec/integration/auto_migrations/managing_columns_spec.rb
@@ -100,4 +100,22 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
       expect(inferred_schema(:users).map(&:name)).to eql(%i(id name email))
     end
   end
+
+  describe 'empty diff' do
+    before do
+      conn.create_table :users do
+        primary_key :id
+        column :name, String, null: false
+        column :email, String
+      end
+    end
+
+    it 'leaves existing schema' do
+      current = container.relation(:users).schema
+
+      gateway.auto_migrate!(container)
+
+      expect(inferred_schema(:users)).to eql(current)
+    end
+  end
 end

--- a/spec/integration/auto_migrations/postgres/column_types_spec.rb
+++ b/spec/integration/auto_migrations/postgres/column_types_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe ROM::SQL::Gateway, :postgres do
+  include_context 'database setup'
+
+  before do
+    conn.drop_table?(:test_pg_types)
+  end
+
+  describe 'common types' do
+    before do
+      conf.relation(:test_pg_types) do
+        schema do
+          attribute :id,              ROM::SQL::Types::Serial
+          attribute :string,          ROM::SQL::Types::String
+          attribute :int,             ROM::SQL::Types::Int
+          attribute :time,            ROM::SQL::Types::Time
+          attribute :date,            ROM::SQL::Types::Date
+          attribute :decimal,         ROM::SQL::Types::Decimal
+          attribute :string_nullable, ROM::SQL::Types::String.optional
+        end
+      end
+    end
+
+    subject(:gateway) { container.gateways[:default] }
+
+    def inferred_schema(rel_name)
+      conf = ROM::Configuration.new(:sql, conn) do |conf|
+        conf.relation(rel_name) do
+          schema(infer: true)
+        end
+      end
+
+      container = ROM.container(conf)
+      container.relation(rel_name).schema
+    end
+
+    it 'has support for PG data types' do
+      gateway.auto_migrate!(conf)
+
+      expect(inferred_schema(:test_pg_types).to_ast)
+        .to eql(
+              [:schema,
+               [ROM::Relation::Name[:test_pg_types],
+                [[:attribute,
+                  [:id,
+                   [:definition, [Integer, {}]],
+                   primary_key: true, source: :test_pg_types]],
+                 [:attribute, [:string, [:definition, [String, {}]], source: :test_pg_types]],
+                 [:attribute, [:int, [:definition, [Integer, {}]], source: :test_pg_types]],
+                 [:attribute, [:time, [:definition, [Time, {}]], source: :test_pg_types]],
+                 [:attribute, [:date, [:definition, [Date, {}]], source: :test_pg_types]],
+                 [:attribute, [:decimal, [:definition, [BigDecimal, {}]], source: :test_pg_types]],
+                 [:attribute,
+                  [:string_nullable,
+                   [:sum,
+                    [[:constrained,
+                      [[:definition, [NilClass, {}]],
+                       [:predicate, [:type?, [[:type, NilClass], [:input, ROM::Undefined]]]],
+                       {}]],
+                     [:definition, [String, {}]],
+                     {}]],
+                   source: :test_pg_types]]]]]
+            )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,11 +61,8 @@ TMP_PATH = root.join('../tmp')
 
 require 'rom/sql/schema/inferrer'
 
-class ROM::SQL::Schema::Inferrer
-  def self.on_error(*)
-    # quiet in specs
-  end
-end
+# quiet in specs
+ROM::SQL::Schema::Inferrer.silent!
 
 require 'dry/core/deprecations'
 Dry::Core::Deprecations.set_logger!(root.join('../log/deprecations.log'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require 'logger'
 require 'tempfile'
 
 begin
-  require 'byebug'
+  require ENV['DEBUGGER'] || 'byebug'
 rescue LoadError
   require 'pry'
 end


### PR DESCRIPTION
This adds support for automatic DB schema migrations based on relation schemas. Target API will look similar to a single simple call `gateway.auto_migrate!(container)`

- [x] Creating a table
- [x] Adding columns to an existing table
- [ ] Renaming columns (without coercion)
- [x] Removing columns
- [ ] Support for default types
- [ ] Emitting migration files
- [x] Friendly errors on unsupported operations
- [x] Managing indexes
- [x] Managing nullability
- [ ] Managing FK constraints