### PR TITLE
Managing foreign keys in auto-migrations

### DIFF
--- a/lib/rom/sql/associations/core.rb
+++ b/lib/rom/sql/associations/core.rb
@@ -14,6 +14,11 @@ module ROM
 
           target.where(target_key => target_pks)
         end
+
+        # @api private
+        def outgoing_reference?
+          false
+        end
       end
     end
   end

--- a/lib/rom/sql/associations/many_to_one.rb
+++ b/lib/rom/sql/associations/many_to_one.rb
@@ -49,6 +49,11 @@ module ROM
         def prepare(target)
           call(target: target, preload: true)
         end
+
+        # @api private
+        def outgoing_reference?
+          true
+        end
       end
     end
   end

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -299,6 +299,13 @@ module ROM
         end
       end
 
+      # Returns a new attribute marked as indexed
+      #
+      # @api public
+      def indexed
+        meta(index: true)
+      end
+
       # @api private
       def meta_ast
         meta = super

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -287,16 +287,7 @@ module ROM
 
       # @api public
       def indexed?
-        !indexes.empty?
-      end
-
-      # @api public
-      def indexes
-        if meta[:index] == true
-          INDEXED
-        else
-          meta[:index] || EMPTY_SET
-        end
+        meta[:index].equal?(true)
       end
 
       # Returns a new attribute marked as indexed
@@ -309,7 +300,7 @@ module ROM
       # @api private
       def meta_ast
         meta = super
-        meta[:index] = indexes if indexed?
+        meta[:index] = true if indexed?
         meta
       end
 

--- a/lib/rom/sql/foreign_key.rb
+++ b/lib/rom/sql/foreign_key.rb
@@ -1,0 +1,23 @@
+module ROM
+  module SQL
+    # @api private
+    class ForeignKey
+      extend Initializer
+      include Dry::Equalizer(:source_attributes, :target_attributes)
+
+      param :source_attributes
+
+      param :target_attributes
+
+      option :name, optional: true
+
+      def source
+        source_attributes[0].source
+      end
+
+      def target
+        target_attributes[0].source
+      end
+    end
+  end
+end

--- a/lib/rom/sql/index.rb
+++ b/lib/rom/sql/index.rb
@@ -24,6 +24,10 @@ module ROM
       def partial?
         !predicate.nil?
       end
+
+      def can_access?(attribute)
+        !partial? && attributes[0].name == attribute.name
+      end
     end
   end
 end

--- a/lib/rom/sql/migration/inline_runner.rb
+++ b/lib/rom/sql/migration/inline_runner.rb
@@ -65,7 +65,7 @@ module ROM
                   drop_column attribute.name
                 when SchemaDiff::AttributeChanged
                   if attribute.type_changed?
-                    from, to = attribute.to_a.map(&attribute.method(:unwrap))
+                    from, to = attribute.current.unwrap, attribute.target.unwrap
                     raise UnsupportedConversion.new(
                             "Don't know how to convert #{ from.inspect } to #{ to.inspect }"
                           )
@@ -105,6 +105,7 @@ module ROM
                 when SchemaDiff::ForeignKeyAdded
                   add_foreign_key fk.constrained_columns, fk.references
                 when SchemaDiff::ForeignKeyRemoved
+                  drop_foreign_key fk.constrained_columns
                 end
               end
             end

--- a/lib/rom/sql/migration/schema_diff.rb
+++ b/lib/rom/sql/migration/schema_diff.rb
@@ -87,16 +87,18 @@ module ROM
             @current = current
           end
 
-          def to_a
-            [current, target]
-          end
-
           def nullability_changed?
             current.optional? ^ target.optional?
           end
 
           def type_changed?
-            unwrap(current).meta(index: Set.new) != unwrap(target).meta(index: Set.new)
+            erase_meta(current) != erase_meta(target)
+          end
+
+          private
+
+          def erase_meta(type)
+            unwrap(type).meta(index: Set.new, foreign_key: nil, target: nil)
           end
         end
 

--- a/lib/rom/sql/schema/inferrer.rb
+++ b/lib/rom/sql/schema/inferrer.rb
@@ -25,8 +25,9 @@ module ROM
           inferred = super
 
           indexes = get_indexes(gateway, schema, inferred[:attributes])
+          indexed_attributes = index_attrbutes(inferred[:attributes], indexes)
 
-          { **inferred, indexes: indexes }
+          { **inferred, indexes: indexes, attributes: indexed_attributes }
         rescue Sequel::Error => error
           on_error(schema.name, error)
           FALLBACK_SCHEMA
@@ -59,6 +60,16 @@ module ROM
         end
 
         private
+
+        def index_attrbutes(attributes, indexes)
+          attributes.map do |attribute|
+            if !attribute.indexed? && indexes.any? { |index| index.can_access?(attribute) }
+              attribute.indexed
+            else
+              attribute
+            end
+          end
+        end
 
         # @api private
         def on_error(dataset, e)

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -14,7 +14,7 @@ module ROM
       end
 
       def self.ForeignKey(relation, type = Types::Int.meta(index: true))
-        type.meta(foreign_key: true, target: relation)
+        super
       end
 
       Serial = Int.meta(primary_key: true)

--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -13,6 +13,10 @@ module ROM
         ROM::Types.Definition(*args, &block)
       end
 
+      def self.ForeignKey(relation, type = Types::Int.meta(index: true))
+        type.meta(foreign_key: true, target: relation)
+      end
+
       Serial = Int.meta(primary_key: true)
 
       Blob = Constructor(Sequel::SQL::Blob, &Sequel::SQL::Blob.method(:new))

--- a/spec/integration/auto_migrations/foreign_keys_spec.rb
+++ b/spec/integration/auto_migrations/foreign_keys_spec.rb
@@ -2,12 +2,14 @@ RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
   include_context 'database setup'
 
   before do
-    conn.drop_table?(:users)
     conn.drop_table?(:posts)
+    conn.drop_table?(:users)
   end
 
   let(:table_name) { :posts }
   let(:relation_name) { ROM::Relation::Name.new(table_name) }
+  let(:posts) { container.relations[:posts] }
+  let(:users) { container.relations[:users] }
 
   subject(:gateway) { conf.gateways[:default] }
 
@@ -36,7 +38,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
       conf.relation(:posts) do
         schema do
           attribute :id,       ROM::SQL::Types::Serial
-          attribute :user_id,  ROM::SQL::Types::ForeignKey(:users).meta(index: true)
+          attribute :user_id,  ROM::SQL::Types::ForeignKey(:users)
         end
       end
 
@@ -52,6 +54,84 @@ RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
       gateway.auto_migrate!(conf)
 
       expect(migrated_schema.foreign_keys.size).to eql(1)
+      expect(migrated_schema.foreign_keys.first).
+        to eql(
+             ROM::SQL::ForeignKey.new([posts[:user_id]], [users[:id]])
+           )
+    end
+  end
+
+  describe 'alter table' do
+    context 'adding' do
+      before do
+        conn.create_table(:users) do
+          primary_key :id
+          column :name, String, null: false
+        end
+
+        conn.create_table(:posts) do
+          primary_key :id
+          column :user_id, Integer, null: false
+        end
+
+        conf.relation(:posts) do
+          schema do
+            attribute :id,       ROM::SQL::Types::Serial
+            attribute :user_id,  ROM::SQL::Types::ForeignKey(:users)
+          end
+        end
+
+        conf.relation(:users) do
+          schema do
+            attribute :id,   ROM::SQL::Types::Serial
+            attribute :name, ROM::SQL::Types::String
+          end
+        end
+      end
+
+      it 'creates foreign key constraints based on schema' do
+        gateway.auto_migrate!(conf)
+
+        expect(migrated_schema.foreign_keys.size).to eql(1)
+        expect(migrated_schema.foreign_keys.first).
+          to eql(
+               ROM::SQL::ForeignKey.new([posts[:user_id]], [users[:id]])
+             )
+      end
+    end
+  end
+
+  context 'removing' do
+    before do
+      conn.create_table(:users) do
+        primary_key :id
+        column :name, String, null: false
+      end
+
+      conn.create_table(:posts) do
+        primary_key :id
+        foreign_key :user_id, :users
+      end
+
+      conf.relation(:posts) do
+        schema do
+          attribute :id,       ROM::SQL::Types::Serial
+          attribute :user_id,  ROM::SQL::Types::Int
+        end
+      end
+
+      conf.relation(:users) do
+        schema do
+          attribute :id,   ROM::SQL::Types::Serial
+          attribute :name, ROM::SQL::Types::String
+        end
+      end
+    end
+
+    it 'removes a foreign key' do
+      gateway.auto_migrate!(conf)
+
+      expect(migrated_schema.foreign_keys.size).to eql(0)
     end
   end
 end

--- a/spec/integration/auto_migrations/foreign_keys_spec.rb
+++ b/spec/integration/auto_migrations/foreign_keys_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
+  include_context 'database setup'
+
+  before do
+    conn.drop_table?(:users)
+    conn.drop_table?(:posts)
+  end
+
+  let(:table_name) { :posts }
+  let(:relation_name) { ROM::Relation::Name.new(table_name) }
+
+  subject(:gateway) { conf.gateways[:default] }
+
+  let(:inferrer) { ROM::SQL::Schema::Inferrer.new }
+
+  let(:gateway_schemas) do
+    conf.relation_classes(gateway).each_with_object({}) do |klass, schemas|
+      schema = klass.schema_proc.call.finalize_attributes!(gateway: gateway)
+      schemas[schema.name.relation] = schema
+    end
+  end
+
+  let(:migrated_schema) do
+    infer_schema(table_name, gateway_schemas)
+  end
+
+  let(:attributes) { migrated_schema.to_a }
+
+  describe 'create table' do
+    before do
+      conn.create_table(:users) do
+        primary_key :id
+        column :name, String, null: false
+      end
+
+      conf.relation(:posts) do
+        schema do
+          attribute :id,       ROM::SQL::Types::Serial
+          attribute :user_id,  ROM::SQL::Types::ForeignKey(:users).meta(index: true)
+        end
+      end
+
+      conf.relation(:users) do
+        schema do
+          attribute :id,   ROM::SQL::Types::Serial
+          attribute :name, ROM::SQL::Types::String
+        end
+      end
+    end
+
+    it 'creates foreign key constraints based on schema' do
+      gateway.auto_migrate!(conf)
+
+      expect(migrated_schema.foreign_keys.size).to eql(1)
+    end
+  end
+end

--- a/spec/integration/auto_migrations/indexes_spec.rb
+++ b/spec/integration/auto_migrations/indexes_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
                     [:attribute,
                      [:name,
                       [:definition, [String, {}]],
-                      index: Set.new([true]),
+                      index: true,
                       source: :users]],
                   ])
 

--- a/spec/integration/auto_migrations/indexes_spec.rb
+++ b/spec/integration/auto_migrations/indexes_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
                     [:attribute,
                      [:name,
                       [:definition, [String, {}]],
+                      index: Set.new([true]),
                       source: :users]],
                   ])
 

--- a/spec/integration/plugins/auto_restrictions_spec.rb
+++ b/spec/integration/plugins/auto_restrictions_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe 'Plugins / :auto_restrictions', seeds: true do
         confs[:one].plugin(:sql, relations: :auto_restrictions)
         confs[:two].plugin(:sql, relations: :auto_restrictions)
 
+        confs[:one].relation(:users) { schema(infer: true) }
+        confs[:two].relation(:users) { schema(infer: true) }
         confs[:one].register_relation(Test::Tasks)
         confs[:two].register_relation(Test::Tasks)
       end

--- a/spec/integration/relation_schema_spec.rb
+++ b/spec/integration/relation_schema_spec.rb
@@ -212,12 +212,7 @@ RSpec.describe 'Inferring schema from database' do
         class Test::Tags < ROM::Relation[:sql]
           schema(:tags) do
             attribute :id,      Types::Serial
-            attribute :post_id, Types::Int.meta(index: true)
-            attribute :user_id, Types::ForeignKey(:users)
-
-            associations do
-              belongs_to :post
-            end
+            attribute :post_id, Types::ForeignKey(:posts).meta(index: true)
           end
         end
 
@@ -225,9 +220,14 @@ RSpec.describe 'Inferring schema from database' do
         config.relation(:users) { schema(infer: true) }
         config.register_relation(Test::Tags)
 
-        schema = container.relations[:tags].schema
+        tags = container.relations[:tags].schema
+        posts = container.relations[:posts].schema
 
-        expect(schema.foreign_keys.size).to eql(2)
+        expect(tags.foreign_keys.size).to eql(1)
+        expect(tags.foreign_keys.first).
+          to eql(
+               ROM::SQL::ForeignKey.new([tags[:post_id]], [posts[:post_id]])
+             )
       end
     end
 

--- a/spec/integration/schema/inferrer_spec.rb
+++ b/spec/integration/schema/inferrer_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'Schema inference for common datatypes', seeds: false do
                    name: :user_id,
                    foreign_key: true,
                    source: source,
-                   target: :users
+                   target: :users,
+                   index: true
                  )
                )
         end

--- a/spec/shared/users_and_tasks.rb
+++ b/spec/shared/users_and_tasks.rb
@@ -20,6 +20,7 @@ RSpec.shared_context 'users and tasks' do
       String :title, text: false
       constraint(:title_length) { char_length(title) > 1 } if ctx.postgres?(example)
       constraint(:title_length) { length(title) > 1 }      if ctx.sqlite?(example)
+      index :user_id
     end
 
     conn.create_table :tags do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -21,4 +21,10 @@ module Helpers
     definition = ROM::Associations::Definitions.const_get(klass).new(*args)
     ROM::SQL::Associations.const_get(definition.type).new(definition, relations)
   end
+
+  def infer_schema(table_name, schemas)
+    empty = define_schema(table_name)
+    schema = empty.with(inferrer.(empty, gateway))
+    schema.set_foreign_keys!(schemas)
+  end
 end


### PR DESCRIPTION
This adds support for managing foreign key constraints within a single gateway. Foreign key list that I added is kind of generic and can be moved later to the core

- [x] Add list of foreign key to the schema
- [x] Check if FKs work fine with the inferrer
- [x] Manage FKs in auto-migrations. It must be the last step because FKs are safe to be created only when all tables are in place