### PR TITLE
Discard old rows before creating new in 1-to-1 associations

### DIFF
--- a/lib/rom/sql/association/one_to_one.rb
+++ b/lib/rom/sql/association/one_to_one.rb
@@ -3,6 +3,13 @@ module ROM
     class Association
       class OneToOne < OneToMany
         result :one
+
+        # @api private
+        def remove_associated(relations, parent)
+          pk, fk = join_key_map(relations)
+          relation = relations[source.relation]
+          relation.where(fk => parent.fetch(pk)).delete
+        end
       end
     end
   end

--- a/lib/rom/sql/plugin/associates.rb
+++ b/lib/rom/sql/plugin/associates.rb
@@ -154,6 +154,11 @@ module ROM
                 else
                   tuples.map { |tuple| Hash(tuple).update(fk => parent[pk]) }
                 end
+              when Association::OneToOne
+                with_input_tuples(tuples).map { |tuple|
+                  assoc.remove_associated(__registry__, parent)
+                  assoc.associate(__registry__, tuple, parent)
+                }
               when Association
                 with_input_tuples(tuples).map { |tuple|
                   assoc.associate(__registry__, tuple, parent)


### PR DESCRIPTION
@solnic please review. I decided not to wrap it in a transaction block because in my opinion this should be done on a higher level. We already have one-to-many (and many-to-many) commands that don't use transactions so I suggest being consistent :)

/cc @mereghost