### PR TITLE
Add missing support for *text types in MySQL

### DIFF
--- a/lib/rom/sql/extensions/mysql/type_builder.rb
+++ b/lib/rom/sql/extensions/mysql/type_builder.rb
@@ -4,6 +4,22 @@ module ROM
   module SQL
     module MySQL
       class TypeBuilder < Schema::TypeBuilder
+        defines :db_type_mapping
+
+        db_type_mapping(
+          'tinytext' => Types::String,
+          'text' => Types::String,
+          'mediumtext' => Types::String,
+          'longtext' => Types::String
+        ).freeze
+
+        def map_type(ruby_type, db_type, **_)
+          map_db_type(db_type) || super
+        end
+
+        def map_db_type(db_type)
+          self.class.db_type_mapping[db_type]
+        end
       end
     end
 

--- a/spec/integration/schema/inferrer/mysql_spec.rb
+++ b/spec/integration/schema/inferrer/mysql_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe 'ROM::SQL::Schema::MysqlInferrer', :mysql do
       timestamp :unix_time_usec
       column :unix_time_sec, 'timestamp(0) null'
       boolean :flag, null: false
+
+      column :ttext, 'tinytext', null: false
+      column :mtext, 'mediumtext', null: false
+      column :rtext, 'text', null: false
+      column :ltext, 'longtext', null: false
     end
   end
 
@@ -56,5 +61,17 @@ RSpec.describe 'ROM::SQL::Schema::MysqlInferrer', :mysql do
     expect(schema[:flag].source).to be(source)
     expect(schema[:flag].unwrap.type.left.primitive).to be(TrueClass)
     expect(schema[:flag].unwrap.type.right.primitive).to be(FalseClass)
+
+    expect(schema[:ttext].source).to be(source)
+    expect(schema[:ttext].unwrap.type.primitive).to be(String)
+
+    expect(schema[:rtext].source).to be(source)
+    expect(schema[:rtext].unwrap.type.primitive).to be(String)
+
+    expect(schema[:mtext].source).to be(source)
+    expect(schema[:mtext].unwrap.type.primitive).to be(String)
+
+    expect(schema[:ltext].source).to be(source)
+    expect(schema[:ltext].unwrap.type.primitive).to be(String)
   end
 end


### PR DESCRIPTION
In MySQL it's possible to define `tinytext`, `text`, `mediumtext` or
`longtext` column types. `rom-sql` currently only supports `text`
and `mediumtext` attributes. This change ensures that `tinytext` and
`longtext` are also supported and adds tests to validate the behavior
for all text types.

Fixes #183