### PR TITLE
[WIP] Support for window functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [BREAKING] based on rom 4.0 now (flash-gordon + solnic)
 * [BREAKING] `Associates` command plugin requires associations now (solnic)
 * [BREAKING] `Command#transaction` is gone in favor of `Relation#transaction` (solnic)
+* [BREAKING] `PG::JSONArray`, `PG::JSONBArray`, `PG::JSONHash`, and `PG::JSONBHash` types were dropped, use `PG::JSON` and `PG::JSONB` instead (flash-gordon)
 * `ManyToOne` no longer uses a join (solnic)
 * `AutoCombine` and `AutoWrap` plugins were removed as this functionality is provided by core API (solnic)
 * Foreign keys are indexed by default (flash-gordon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@
 * Add DLS for describing table indexes (flash-gordon)
 
   ```ruby
-  schema do
-    indexes do
-      index :name, name: :unique_name, unique: true
-      index :props, type: :gin
-      index :name, name: :long_names_only, predicate: 'length(name) > 10'
-      index :user_id, :title, name: :composite_idx
+    schema do
+      indexes do
+        index :name, name: :unique_name, unique: true
+        index :props, type: :gin
+        index :name, name: :long_names_only, predicate: 'length(name) > 10'
+        index :user_id, :title, name: :composite_idx
+      end
     end
-  end
   ```
 
 * Support for composite indexes in the auto-restrictions plugin (flash-gordon)
@@ -58,6 +58,12 @@
 
   ```ruby
     users.by_pk(1).explain(format: :json, analyze: true)
+  ```
+
+* Support for window function calls
+
+  ```ruby
+    employees.select { [dep_no, salary, int::avg(salary).over(partition: dep_no, order: id).as(:avg_salary)] }
   ```
 
 

--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -2,9 +2,10 @@ require 'rom/attribute'
 
 module ROM
   module SQL
-    # @api private
+    # @api public
     class Function < ROM::Attribute
       class << self
+        # @api private
         def frame_limit(value)
           case value
           when :current then 'CURRENT ROW'
@@ -22,6 +23,7 @@ module ROM
         private :frame_limit
       end
 
+      # @api private
       WINDOW_FRAMES = Hash.new do |cache, frame|
         type = frame.key?(:rows) ? 'ROWS' : 'RANGE'
         bounds = frame[:rows] || frame[:range]
@@ -33,6 +35,7 @@ module ROM
       WINDOW_FRAMES[:rows] = WINDOW_FRAMES[rows: [:start, :current]]
       WINDOW_FRAMES[range: :current] = WINDOW_FRAMES[range: [:current, :current]]
 
+      # @api private
       def sql_literal(ds)
         if name
           ds.literal(func.as(name))
@@ -41,20 +44,59 @@ module ROM
         end
       end
 
+      # @api private
       def name
         meta[:alias] || super
       end
 
+      # @api private
       def qualified(table_alias = nil)
         meta(
           func: ::Sequel::SQL::Function.new(func.name, *func.args.map { |arg| arg.respond_to?(:qualified) ? arg.qualified(table_alias) : arg })
         )
       end
 
+      # @api private
       def is(other)
         ::Sequel::SQL::BooleanExpression.new(:'=', func, other)
       end
 
+      # Add an OVER clause making a window function call
+      # @see https://www.postgresql.org/docs/9.6/static/tutorial-window.html
+      #
+      # @example
+      #   users.select { [id, int::row_number().over(partition: name, order: id).as(:row_no)] }
+      #   users.select { [id, int::row_number().over(partition: [first_name, last_name], order: id).as(:row_no)] }
+      #
+      # @example frame variants
+      #   # ROWS BETWEEN 3 PRECEDING AND CURRENT ROW
+      #   row_number.over(frame: { rows: [-3, :current] })
+      #
+      #   # ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING
+      #   row_number.over(frame: { rows: [-3, 3] })
+      #
+      #   # ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+      #   row_number.over(frame: { rows: [:start, :current] })
+      #
+      #   # ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+      #   row_number.over(frame: { rows: [:current, :end] })
+      #
+      # @example frame shortcuts
+      #   # ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      #   row_number.over(frame: :all)
+      #
+      #   # ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      #   row_number.over(frame: :rows)
+      #
+      #   # RANGE BETWEEN CURRENT ROW AND CURRENT ROW
+      #   row_number.over(frame: { range: :current} )
+      #
+      # @option :partition [Array<SQL::Attribute>,SQL::Attribute] A PARTITION BY part
+      # @option :order [Array<SQL::Attribute>,SQL::Attribute] An ORDER BY part
+      # @option :frame [Hash,Symbol] A frame part (RANGE or ROWS, see examples)
+      # @return [SQL::Function]
+      #
+      # @api public
       def over(partition: nil, order: nil, frame: nil)
         super(partition: partition, order: order, frame: WINDOW_FRAMES[frame])
       end
@@ -63,23 +105,26 @@ module ROM
       #
       # @example
       #   users.select { bool::cast(json_data.get_text('activated'), :boolean).as(:activated) }
+      #   users.select { bool::cast(json_data.get_text('activated')).as(:activated) }
       #
       # @param [ROM::SQL::Attribute] expr Expression to be cast
-      # @param [String] db_type Target database type
+      # @param [String] db_type Target database type (usually can be inferred from the target data type)
       #
       # @return [ROM::SQL::Attribute]
       #
-      # @api private
+      # @api public
       def cast(expr, db_type = TypeSerializer[:default].call(type))
         Attribute[type].meta(sql_expr: ::Sequel.cast(expr, db_type))
       end
 
       private
 
+      # @api private
       def func
         meta[:func]
       end
 
+      # @api private
       def method_missing(meth, *args)
         if func
           if func.respond_to?(meth)

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe ROM::SQL::Function, :postgres do
 
       expect(func.row_number.over(frame: { rows: [-3, :end] }).sql_literal(ds)).
         to eql('ROW_NUMBER() OVER (ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING)')
+
+      expect(func.row_number.over(frame: { rows: [3, 6] }).sql_literal(ds)).
+        to eql('ROW_NUMBER() OVER (ROWS BETWEEN 3 FOLLOWING AND 6 FOLLOWING)')
+
+      expect(func.row_number.over(frame: { rows: [-6, -3] }).sql_literal(ds)).
+        to eql('ROW_NUMBER() OVER (ROWS BETWEEN 6 PRECEDING AND 3 PRECEDING)')
     end
 
     it 'supports aliases' do


### PR DESCRIPTION
This adds support for calling window functions from rom-sql. Technically, we
were able to call them before because Sequel implements their support and this
commit just adds specs for the implementation so that we can guarantee backward
compatibility (though it's generally not an issue with Sequel :). What I added
is a frame clause builder because we don't like passing SQL strings around.

See https://en.wikipedia.org/wiki/Select_(SQL)#Window_function for more details
on window functions.

- [x] Support for calling window functions
- [x] Add docs