### PR TITLE
Remove redundant require.

### DIFF
--- a/lib/rom/sql/types.rb
+++ b/lib/rom/sql/types.rb
@@ -1,5 +1,4 @@
 require 'sequel/core'
-require 'sequel/sql'
 
 require 'rom/types'
 require 'rom/sql/type_dsl'


### PR DESCRIPTION
'sequel/core' now uses require_relative to load 'sequel/sql'.

Requiring twice causes a RuntimeError because Sequel5 now freezes instance variables.