### PR TITLE
[PG] arrays with member coercions

### DIFF
--- a/lib/rom/sql/extensions/postgres/type_builder.rb
+++ b/lib/rom/sql/extensions/postgres/type_builder.rb
@@ -51,7 +51,10 @@ module ROM
 
         def map_type(ruby_type, db_type, enum_values: nil, **_)
           if db_type.end_with?(self.class.db_array_type_matcher)
-            Types::Array(db_type[0...-2])
+            member_name = db_type[0...-2]
+            member_type = self.class.db_type_mapping[member_name]
+
+            Types::Array(member_name, member_type)
           elsif enum_values
             SQL::Types::String.enum(*enum_values)
           else

--- a/lib/rom/sql/extensions/postgres/types/array.rb
+++ b/lib/rom/sql/extensions/postgres/types/array.rb
@@ -10,18 +10,67 @@ module ROM
 
         ArrayRead = Array.constructor { |v| v.respond_to?(:to_ary) ? v.to_ary : v }
 
-        constructor = -> type { -> value { Sequel.pg_array(value, type) } }
+        # @api private
+        class ArrayTypes
+          attr_reader :elements
 
-        @array_types = ::Hash.new do |hash, type|
-          name = "#{ type }[]"
-          array_type = Type(name, Array.constructor(constructor.(type))).
-                         meta(type: type, read: ArrayRead)
-          TypeExtensions.register(array_type) { include ArrayMethods }
-          hash[type] = array_type
+          attr_reader :constructor
+
+          attr_reader :base_write_type
+
+          attr_reader :base_read_type
+
+          def initialize
+            @elements = {}
+            @base_write_type = Postgres::Types::Array
+            @base_read_type = ArrayRead
+            @constructor = proc { |db_type, member|
+              -> arr {
+                if member
+                  Sequel.pg_array(arr.map { |v| member[v] }, db_type)
+                else
+                  Sequel.pg_array(arr, db_type)
+                end
+              }
+            }
+          end
+
+          def [](db_type, member_type = nil)
+            elements.fetch(db_type) do
+              name = "#{db_type}[]"
+
+              write_array =
+                if member_type
+                  base_write_type.constructor(constructor[db_type, member_type])
+                else
+                  base_write_type.constructor(constructor[db_type])
+                end
+
+              read_array =
+                if member_type && member_type.meta[:read]
+                  base_read_type.of(member_type.meta[:read])
+                else
+                  base_read_type
+                end
+
+              array_type = Types.Type(name, write_array).
+                             meta(type: db_type, read: read_array)
+
+              TypeExtensions.register(array_type) { include ArrayMethods }
+
+              elements[db_type] = array_type
+            end
+          end
         end
 
-        def self.Array(db_type)
-          @array_types[db_type]
+        # @api private
+        def self.array_types
+          @array_types ||= ArrayTypes.new
+        end
+
+        # @api private
+        def self.Array(db_type, member_type = nil)
+          array_types[db_type, member_type]
         end
 
         # @!parse

--- a/lib/rom/sql/extensions/postgres/types/array.rb
+++ b/lib/rom/sql/extensions/postgres/types/array.rb
@@ -39,27 +39,37 @@ module ROM
             elements.fetch(db_type) do
               name = "#{db_type}[]"
 
-              write_array =
-                if member_type
-                  base_write_type.constructor(constructor[db_type, member_type])
-                else
-                  base_write_type.constructor(constructor[db_type])
-                end
+              write_type = build_write_type(db_type, member_type)
+              read_type = build_read_type(db_type, member_type)
 
-              read_array =
-                if member_type && member_type.meta[:read]
-                  base_read_type.of(member_type.meta[:read])
-                else
-                  base_read_type
-                end
+              array_type = Types.Type(name, write_type).meta(type: db_type, read: read_type)
 
-              array_type = Types.Type(name, write_array).
-                             meta(type: db_type, read: read_array)
-
-              TypeExtensions.register(array_type) { include ArrayMethods }
+              register_extension(array_type)
 
               elements[db_type] = array_type
             end
+          end
+
+          private
+
+          def build_write_type(db_type, member_type)
+            if member_type
+              base_write_type.constructor(constructor[db_type, member_type])
+            else
+              base_write_type.constructor(constructor[db_type])
+            end
+          end
+
+          def build_read_type(db_type, member_type)
+            if member_type && member_type.meta[:read]
+              base_read_type.of(member_type.meta[:read])
+            else
+              base_read_type
+            end
+          end
+
+          def register_extension(type)
+            TypeExtensions.register(type) { include ArrayMethods }
           end
         end
 

--- a/lib/rom/sql/extensions/postgres/types/array_types.rb
+++ b/lib/rom/sql/extensions/postgres/types/array_types.rb
@@ -1,0 +1,72 @@
+require 'rom/sql/type_extensions'
+
+module ROM
+  module SQL
+    module Postgres
+      module Types
+        # @api private
+        class ArrayTypes
+          attr_reader :elements
+
+          attr_reader :constructor
+
+          attr_reader :base_write_type
+
+          attr_reader :base_read_type
+
+          def initialize(base_write_type, base_read_type)
+            @elements = {}
+            @base_write_type = base_write_type
+            @base_read_type = base_read_type
+            @constructor = proc { |db_type, member|
+              -> arr {
+                if member
+                  Sequel.pg_array(arr.map { |v| member[v] }, db_type)
+                else
+                  Sequel.pg_array(arr, db_type)
+                end
+              }
+            }
+          end
+
+          def [](db_type, member_type = nil)
+            elements.fetch(db_type) do
+              name = "#{db_type}[]"
+
+              write_type = build_write_type(db_type, member_type)
+              read_type = build_read_type(db_type, member_type)
+
+              array_type = Types.Type(name, write_type).meta(type: db_type, read: read_type)
+
+              register_extension(array_type)
+
+              elements[db_type] = array_type
+            end
+          end
+
+          private
+
+          def build_write_type(db_type, member_type)
+            if member_type
+              base_write_type.constructor(constructor[db_type, member_type])
+            else
+              base_write_type.constructor(constructor[db_type])
+            end
+          end
+
+          def build_read_type(db_type, member_type)
+            if member_type && member_type.meta[:read]
+              base_read_type.of(member_type.meta[:read])
+            else
+              base_read_type
+            end
+          end
+
+          def register_extension(type)
+            TypeExtensions.register(type) { include ArrayMethods }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/postgres/attribute/array_spec.rb
+++ b/spec/extensions/postgres/attribute/array_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe 'ROM::SQL::Attribute / PG array', :postgres do
+  subject(:relation) { relations[:pg_arrays] }
+
+  include_context 'database setup'
+
+  before do
+    conf.relation(:pg_arrays) do
+      schema(infer: true)
+    end
+  end
+
+  after do
+    conn.drop_table(:pg_arrays)
+  end
+
+  context 'with a primitive type' do
+    before do
+      conn.create_table :pg_arrays do
+        column :numbers, 'int[]'
+      end
+    end
+
+    it 'loads an array with integers' do
+      relation.command(:create).call(numbers: [3, 1, 2])
+
+      tuples = relation.to_a
+
+      expect(tuples).to eql([{ numbers: [3, 1, 2] }])
+
+      expect(tuples[0][:numbers]).to be_instance_of(Array)
+    end
+  end
+
+  context 'with a custom json type' do
+    before do
+      conn.create_table :pg_arrays do
+        column :meta, 'json[]'
+      end
+    end
+
+    it 'loads an array with json hashes' do
+      relation.command(:create).call(meta: [{ one: '1', two: '2' }])
+
+      tuples = relation.to_a
+
+      expect(tuples).to eql([{ meta: [{ 'one' => '1', 'two' => '2' }] }])
+
+      expect(tuples[0][:meta]).to be_instance_of(Array)
+      expect(tuples[0][:meta][0]).to be_instance_of(Hash)
+    end
+  end
+end


### PR DESCRIPTION
This fixes a problem (but you can also say it adds a new feature 😆) where using pg arrays with custom types would not result in custom types that we have registered to be used as member types. ie `uuid[]` would not use our `Types::PG::UUID` to process array members.