### PR TITLE
Allow hash-params for the connection

### DIFF
--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -213,6 +213,8 @@ module ROM
         case uri
         when ::Sequel::Database
           uri
+        when Hash
+          ::Sequel.connect(uri, *args)
         else
           ::Sequel.connect(uri.to_s, *args)
         end


### PR DESCRIPTION
Sequel.connect supports Hash for the connection params so should rom-sql.

```ruby
require 'rom'

connection_params = {
  adapter: 'postgresql',
  host: 'myhost',
  database: 'development',
  user: 'foo',
  password: 'bar',
  schema_search_path: 'myschema, public'
}

ROM.container(:sql, connection_params)
```
Wasn't sure if I could just remove the to_s (which leads to the problem) without any side-effects so I just added another when Statement.
There is no test at the moment as I wasn't quite sure where to put it but if the change itself is ok and you tell me where it would fit best I'll certainly add one.
