### PR TITLE
Refactor instrumentation plugin and enable logging all sql

### DIFF
--- a/lib/rom/plugins/relation/sql/instrumentation.rb
+++ b/lib/rom/plugins/relation/sql/instrumentation.rb
@@ -1,22 +1,50 @@
-require 'rom/plugins/relation/instrumentation'
-
 module ROM
   module Plugins
     module Relation
       module SQL
         # @api private
         module Instrumentation
-          def self.included(klass)
-            super
+          extend Notifications::Listener
 
-            klass.class_eval do
-              include ROM::Plugins::Relation::Instrumentation
+          subscribe('configuration.relations.registry.created') do |event|
+            registry = event[:registry]
 
-              # @api private
-              def notification_payload(relation)
-                super.merge(query: relation.dataset.sql)
+            relations = registry.select { |_, r| r.adapter == :sql && r.respond_to?(:notifications) }.to_h
+            db_notifications = relations.values.map { |r| [r.dataset.db, r.notifications] }.uniq.to_h
+
+            db_notifications.each do |db, notifications|
+              instrumenter = Instrumenter.new(db.database_type, notifications)
+              db.extend(instrumenter)
+            end
+          end
+
+          class Instrumenter < Module
+            attr_reader :name
+            attr_reader :notifications
+
+            def initialize(name, notifications)
+              @name = name
+              @notifications = notifications
+              define_log_connection_yield
+            end
+
+            private
+
+            def define_log_connection_yield
+              name = self.name
+              notifications = self.notifications
+
+              define_method(:log_connection_yield) do |*args, &block|
+                notifications.instrument(:sql, name: name, query: args[0]) do
+                  super(*args, &block)
+                end
               end
             end
+          end
+
+          def self.included(klass)
+            super
+            klass.option :notifications
           end
         end
       end

--- a/spec/unit/relation/instrument_spec.rb
+++ b/spec/unit/relation/instrument_spec.rb
@@ -19,27 +19,25 @@ RSpec.describe ROM::SQL::Relation, '#instrument', :sqlite do
     users.to_a
 
     expect(notifications).
-      to have_received(:instrument).with(:sql, name: :users, query: users.dataset.sql)
+      to have_received(:instrument).with(:sql, name: :sqlite, query: users.dataset.sql)
   end
 
   it 'instruments methods that return a single tuple' do
     users.first
 
     expect(notifications).
-      to have_received(:instrument).with(:sql, name: :users, query: users.limit(1).dataset.sql)
+      to have_received(:instrument).with(:sql, name: :sqlite, query: users.limit(1).dataset.sql)
 
     users.last
 
     expect(notifications).
-      to have_received(:instrument).with(:sql, name: :users, query: users.reverse.limit(1).dataset.sql)
+      to have_received(:instrument).with(:sql, name: :sqlite, query: users.reverse.limit(1).dataset.sql)
   end
 
   it 'instruments aggregation methods' do
-    pending "no idea how to make this work with sequel"
-
     users.count
 
     expect(notifications).
-      to have_received(:instrument).with(:sql, name: :users, query: 'SELECT COUNT(*) FROM users')
+      to have_received(:instrument).with(:sql, name: :sqlite, query: "SELECT count(*) AS 'count' FROM `users` LIMIT 1")
   end
 end


### PR DESCRIPTION
This changes instrumentation plugin to be an sql-specific instrumentation. Unfortunately we can't re-use instrumentation from core, simply because in order to log all queries we are forced to hook into `log_connection_yield` which is defined on sequel's database objects (aka db connections). In the context of this method, we do not have access to relations, and I don't think it's possible to provide that, since it's a database object that's shared across all relations.