### PR TITLE
address a bug with postgres RETURNING and alias columns

### DIFF
--- a/lib/rom/sql/extensions/postgres/commands.rb
+++ b/lib/rom/sql/extensions/postgres/commands.rb
@@ -15,7 +15,7 @@ module ROM
           #
           # @api private
           def returning_dataset
-            relation.dataset.returning(*relation.columns)
+            relation.dataset.returning(*relation.qualified_columns)
           end
         end
 


### PR DESCRIPTION
previously, would get an error from postgres when inserting or updating
a relation with an aliased column in the schema:

     ROM::SQL::DatabaseError:                                                                           w
        PG::UndefinedColumn: ERROR:  column "name" does not exist
        LINE 1:    , "active") VALUES ('Joe', 1, true) RETURNING "name", "i...

this is because the returning clause used the final set of column names
from the schema (introduced in 2.1.0) which failed to take into account
that some of those names might be aliases defined within the relation's
schema.