### PR TITLE
Support for functions with any return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.3.1 to-be-released
+
+### Added
+
+* Support for functions with `Any` return type (GustavoCaso)
+
 ## v2.3.0 2017-11-17
 
 ### Added

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -28,6 +28,10 @@ module ROM
         super || type(name)
       end
 
+      def f(name, attr)
+        ::ROM::SQL::Function.new(::ROM::Types::Any, schema: schema).public_send(name, attr)
+      end
+
       private
 
       # @api private

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -28,9 +28,10 @@ module ROM
         super || type(name)
       end
 
-      def f(name, attr)
+      def function(name, attr)
         ::ROM::SQL::Function.new(::ROM::Types::Any, schema: schema).public_send(name, attr)
       end
+      alias_method :f, :function
 
       private
 

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -23,15 +23,26 @@ module ROM
         ::ROM::SQL::Attribute.new(type(:string)).meta(sql_expr: expr)
       end
 
-      # @api private
-      def respond_to_missing?(name, include_private = false)
-        super || type(name)
-      end
-
+      # Return a SQL function with value `Any`
+      #
+      # @example
+      #   users.select { function(:count, :id).as(:total) }
+      #
+      # @param [Symbol] name SQL function
+      # @param [Symbol] attr
+      #
+      # @return [Rom::SQL::Function]
+      #
+      # @api public
       def function(name, attr)
         ::ROM::SQL::Function.new(::ROM::Types::Any, schema: schema).public_send(name, attr)
       end
       alias_method :f, :function
+
+      # @api private
+      def respond_to_missing?(name, include_private = false)
+        super || type(name)
+      end
 
       private
 

--- a/spec/unit/projection_dsl_spec.rb
+++ b/spec/unit/projection_dsl_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ROM::SQL::ProjectionDSL, :postgres, helpers: true do
 
     it 'supports functions with any as return type' do
       literals = dsl
-                   .call { f(:count, :id).as(:count) }
+                   .call { function(:count, :id).as(:count) }
                    .map { |attr| attr.sql_literal(ds) }
 
       expect(literals).to eql([%(COUNT("id") AS "count")])

--- a/spec/unit/projection_dsl_spec.rb
+++ b/spec/unit/projection_dsl_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe ROM::SQL::ProjectionDSL, :postgres, helpers: true do
       expect(literals).to eql([%(COUNT("id") AS "count")])
     end
 
+    it 'supports functions with any as return type' do
+      literals = dsl
+                   .call { f(:count, :id).as(:count) }
+                   .map { |attr| attr.sql_literal(ds) }
+
+      expect(literals).to eql([%(COUNT("id") AS "count")])
+    end
+
     it 'supports functions with arg being a qualified attribute' do
       literals = dsl
                    .call { int::count(id.qualified).as(:count) }


### PR DESCRIPTION
Fixes #270 

Thanks to @solnic and @flash-gordon for the indications to implement this one.

At the end, we decided to go with `select { f(:count, :id).as(:count), concat(:first_name, :last_name).as(:full_name) }` for brevety 