### PR TITLE
Add Relation#as_hash

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -919,6 +919,24 @@ module ROM
           end
         end
 
+        # Returns hash with all tuples being
+        # the key of each the provided attribute
+        #
+        # @example default use primary_key
+        #   users.as_hash
+        #   # {1 => {id: 1, name: 'Jane'}}
+        #
+        # @example using other attribute
+        #   users.as_hash(:name)
+        #   # {'Jane' => {id: 1, name: 'Jane'}}
+        #
+        # @return [Hash]
+        #
+        # @api public
+        def as_hash(attribute = primary_key)
+          dataset.as_hash(attribute)
+        end
+
         private
 
         # Build a locking clause

--- a/spec/unit/relation/as_hash_spec.rb
+++ b/spec/unit/relation/as_hash_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe ROM::Relation, '#as_hash' do
+  subject(:relation) { container.relations.users }
+
+  include_context 'users and tasks'
+
+  before do
+    conf.relation(:users) do
+      schema(infer: true)
+    end
+  end
+
+  with_adapters do
+    it 'returns a hash with all tuples been the key the primary key' do
+      expect(relation.as_hash).to eql({1 => {id: 1, name: 'Jane'}, 2 => {id: 2, name: 'Joe'}})
+    end
+
+    it 'returns a hash with all tuples been the key the one specify in the args' do
+      expect(relation.as_hash(:name)).to eql({'Jane' => {id: 1, name: 'Jane'}, 'Joe' => {id: 2, name: 'Joe'}})
+    end
+  end
+end


### PR DESCRIPTION
Resolves #272 

Add `Relation#as_hash`

@flash-gordon my first iteration was not delegating to `dataset`

```ruby
def as_hash(attribute = primary_key)
   to_a.each_with_object({}) do |tuple, result|
      result[tuple[attribute]] = tuple
   end
end
```

But since is already implemented in `Sequel` I thought it might be a good idea.