### PR TITLE
Optimize `pluck` to select only the column specified in SQL

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -155,7 +155,7 @@ module ROM
         #
         # @api public
         def pluck(name)
-          map(name)
+          select(name).map(name)
         end
 
         # Rename columns in a relation


### PR DESCRIPTION
This optimizes SELECT queries to only select the column needed for `pluck`