### PR TITLE
Fix has_many through join query

### DIFF
--- a/lib/rom/sql/associations/many_to_many.rb
+++ b/lib/rom/sql/associations/many_to_many.rb
@@ -36,8 +36,14 @@ module ROM
         # @api public
         def join(type, source = self.source, target = self.target)
           through_assoc = source.associations[through]
+
+          # first we join source to intermediary
           joined = through_assoc.join(type, source)
-          joined.__send__(type, target.name.dataset, join_keys).qualified
+
+          # then we join intermediary to target
+          target_ds  = target.name.dataset
+          through_jk = through_assoc.target.associations[target_ds].join_keys
+          joined.__send__(type, target_ds, through_jk).qualified
         end
 
         # @api public


### PR DESCRIPTION
It looks as if I stumbled across [the same issue](https://github.com/rom-rb/rom-sql/issues/279#issuecomment-391043656). This should fix it.

I have not included a unit test because I am not sure how to test it effectively. However, that the tests passed both before and after the change suggest the join conditions are not currently being verified.