### PR TITLE
reject attributes that do not have dataset when qualifying

### DIFF
--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -62,6 +62,7 @@ module ROM
       # @api public
       def qualified(table_alias = nil)
         return self if qualified? && table_alias.nil?
+        return meta(qualified: false) unless qualifiable?
 
         case sql_expr
         when Sequel::SQL::AliasedExpression, Sequel::SQL::Identifier, Sequel::SQL::QualifiedIdentifier
@@ -112,6 +113,15 @@ module ROM
       # @api public
       def qualified?
         meta[:qualified].equal?(true) || meta[:qualified].is_a?(Symbol)
+      end
+
+      # Return if an attribute is qualifiable
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def qualifiable?
+        !source.nil?
       end
 
       # Return a new attribute marked as a FK

--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -60,6 +60,13 @@ module ROM
         )
       end
 
+      # @see Attribute#qualified?
+      #
+      # @api private
+      def qualified?(table_alias = nil)
+        meta[:func].args.all?(&:qualified?)
+      end
+
       # @see ROM::SQL::Attribute#is
       #
       # @api public

--- a/spec/unit/relation/qualified_spec.rb
+++ b/spec/unit/relation/qualified_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ROM::Relation, '#qualified' do
     it 'qualifies all attributes' do
       qualified = relation.qualified
 
-      expect(qualified.schema.all?(&:qualified)).to be(true)
+      expect(qualified.schema.all?(&:qualified?)).to be(true)
     end
 
     it 'qualifies virtual attributes' do
@@ -17,9 +17,15 @@ RSpec.describe ROM::Relation, '#qualified' do
                     qualified.
                     group(:id)
 
-      expect(qualified.schema.all?(&:qualified)).to be(true)
+      expect(qualified.schema.all?(&:qualified?)).to be(true)
 
       expect(qualified.to_a).to eql([{ id: 1, count: 1 }, { id: 2, count: 1 }])
+    end
+
+    it 'does not qualify attribute without dataset' do
+      qualified = relation.select_append { `'hello'`.as(:bar) }.qualified
+
+      expect(qualified.schema.all?(&:qualified?)).to be(false)
     end
   end
 end


### PR DESCRIPTION
@solnic here is the cherry pick for the `release-2.5`