### PR TITLE
Fix `ProjectionDSL#function` arguments accepting

### DIFF
--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -34,8 +34,8 @@ module ROM
       # @return [Rom::SQL::Function]
       #
       # @api public
-      def function(name, attr)
-        ::ROM::SQL::Function.new(::ROM::Types::Any, schema: schema).public_send(name, attr)
+      def function(name, *attrs)
+        ::ROM::SQL::Function.new(::ROM::Types::Any, schema: schema).public_send(name, *attrs)
       end
       alias_method :f, :function
 

--- a/spec/unit/projection_dsl_spec.rb
+++ b/spec/unit/projection_dsl_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe ROM::SQL::ProjectionDSL, :postgres, helpers: true do
       expect(literals).to eql([%(COUNT("id") AS "count")])
     end
 
+    it 'supports multi-agrs functions with any as return type' do
+      literals = dsl
+                   .call { function(:if, id > 0, id, nil).as(:id) }
+                   .map { |attr| attr.sql_literal(ds) }
+
+      expect(literals).to eql([%(IF(("id" > 0), "id", NULL) AS "id")])
+    end
+
     it 'supports functions with arg being a qualified attribute' do
       literals = dsl
                    .call { int::count(id.qualified).as(:count) }


### PR DESCRIPTION
Since `Sequel::SQL::Function` accepts multiple parameters as the target
function arguments.