### PR TITLE
Add support for CASE expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## to-be-released
+
+### Added
+
+* Support for `CASE` expression (wmaciejak + flash-gordon)
+
+  ```ruby
+  # matching expression result
+  users.select_append { id.case(1 => string('one'), else: string('something else')).as(:one_or_else) }
+
+  # searching for `true` result
+  users.select_append { string::case(id.is(1) => 'one', else: 'else').as(:one_or_else) }
+  ```
+
+[Compare v2.5.0...master](https://github.com/rom-rb/rom-sql/compare/v2.5.0...master)
+
 ## v2.5.0 2018-06-08
 
 ### Added

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -331,6 +331,21 @@ module ROM
         self.class.new(type.with(meta: cleaned_meta), options)
       end
 
+      def value(value)
+        meta(sql_expr: Sequel[value])
+      end
+
+      def case(mapping)
+        mapping = mapping.dup
+        otherwise = mapping.delete(:else) do
+          raise ArgumentError, 'provide the default case using the :else keyword'
+        end
+
+        type = mapping.values[0].type
+
+        Attribute[type].meta(sql_expr: ::Sequel.case(mapping, otherwise, self))
+      end
+
       private
 
       # Return Sequel Expression object for an attribute

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -331,10 +331,29 @@ module ROM
         self.class.new(type.with(meta: cleaned_meta), options)
       end
 
+      # Wrap a value with the type, it allows using attribute and type specific methods
+      # on literals and things like this
+      #
+      # @param [Object] value any SQL-serializable value
+      # @return [SQL::Attribute]
+      #
+      # @api public
       def value(value)
         meta(sql_expr: Sequel[value])
       end
 
+      # Build a case expression based on attribute. See SQL::Function#case
+      # when you don't have a specific expression after the CASE keyword.
+      # Pass the :else keyword to provide the catch-all case, it's mandatory
+      # because of the Sequel's API used underneath.
+      #
+      # @example
+      #   users.select_append { id.case(1 => `'first'`, else: `'other'`).as(:first_or_not) }
+      #
+      # @param [Hash] mapping mapping between SQL expressions
+      # @return [SQL::Attribute]
+      #
+      # @api public
       def case(mapping)
         mapping = mapping.dup
         otherwise = mapping.delete(:else) do

--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -151,12 +151,13 @@ module ROM
       # @return [ROM::SQL::Attribute]
       #
       # @api public
-      def case(*args, **opts)
-        if opts[:expr]
-          Attribute[type].meta(sql_expr: ::Sequel.case(*args, opts[:expr]))
-        else
-          Attribute[type].meta(sql_expr: ::Sequel.case(*args))
+      def case(mapping)
+        mapping = mapping.dup
+        otherwise = mapping.delete(:else) do
+          raise ArgumentError, 'provide the default case using the :else keyword'
         end
+
+        Attribute[type].meta(sql_expr: ::Sequel.case(mapping, otherwise))
       end
 
       # Add a FILTER clause to aggregate function (supported by PostgreSQL 9.4+)

--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -139,15 +139,14 @@ module ROM
         Attribute[type].meta(sql_expr: ::Sequel.cast(expr, db_type))
       end
 
-      # Add a CASE clause for handling if/then logic
+      # Add a CASE clause for handling if/then logic. This version of CASE search for the first
+      # branch which evaluates to `true`. See SQL::Attriubte#case if you're looking for the
+      # version that matches an expression result
       #
       # @example
-      #   users.select { string::case(status, { "active" => true }, false).as(:activated) }
-      #   users.select { string::case({ "active" => true }, false).as(:activated) }
-      #   users.select { string::case([[{ status: ["active", nil]}, true]], false) }
+      #   users.select { bool::case(status.is("active") => true, else: false).as(:activated) }
       #
-      # @param [ROM::SQL::Attribute] expr Expression consist of 3 args - conditions, default value and optional expression
-      #
+      # @param [Hash] mapping mapping between boolean SQL expressions to arbitrary SQL expressions
       # @return [ROM::SQL::Attribute]
       #
       # @api public

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -54,7 +54,11 @@ module ROM
           type = type(meth)
 
           if type
-            ::ROM::SQL::Function.new(type, schema: schema)
+            if args.empty?
+              ::ROM::SQL::Function.new(type, schema: schema)
+            else
+              ::ROM::SQL::Attribute[type].value(args[0])
+            end
           else
             super
           end

--- a/spec/unit/attribute_spec.rb
+++ b/spec/unit/attribute_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe ROM::SQL::Attribute, :postgres do
     end
   end
 
+  describe '#case' do
+    it 'builds a CASE expression based on attribute' do
+      string_type = ROM::SQL::Attribute[ROM::SQL::Types::String]
+      mapping = {
+        1 => string_type.value('first'),
+        else: string_type.value('second')
+      }
+      expect(users[:id].case(mapping).as(:mapped_id).sql_literal(ds)).
+        to eql(%[(CASE "users"."id" WHEN 1 THEN 'first' ELSE 'second' END) AS "mapped_id"])
+    end
+  end
+
   describe 'extensions' do
     before do
       ROM::SQL::TypeExtensions.instance_variable_get(:@types)['sqlite'].delete('custom')

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -62,26 +62,24 @@ RSpec.describe ROM::SQL::Function, :postgres do
   end
 
   describe '#case' do
-    context 'when additional expression is provided' do
+    # context 'when additional expression is provided' do
+    #   it 'returns an sql expression' do
+    #     expect(func.case({ 1 => "first" }, "last", expr: users[:id]).sql_literal(ds))
+    #       .to eql(%((CASE "users"."id" WHEN 1 THEN 'first' ELSE 'last' END)))
+    #   end
+    # end
+
+    context 'when condition argument is a Hash' do
       it 'returns an sql expression' do
-        expect(func.case({ 1 => "first" }, "last", expr: users[:id]).sql_literal(ds))
-          .to eql(%((CASE "users"."id" WHEN 1 THEN 'first' ELSE 'last' END)))
+        expect(func.case('1' => "first", else: "last").sql_literal(ds)).
+          to eql(%((CASE WHEN '1' THEN 'first' ELSE 'last' END)))
       end
     end
 
-    context 'when additional expression is not provided' do
-      context 'when condition argument is a Hash' do
-        it 'returns an sql expression' do
-          expect(func.case({ '1' => "first" }, "last").sql_literal(ds))
-            .to eql(%((CASE WHEN '1' THEN 'first' ELSE 'last' END)))
-        end
-      end
-
-      context 'when condition argument is an Array' do
-        it 'returns an sql expression' do
-          expect(func.case([[{ users[:id] => [1, 2] }, 'first']], 'last').sql_literal(ds))
-            .to eql(%((CASE WHEN ("users"."id" IN (1, 2)) THEN 'first' ELSE 'last' END)))
-        end
+    context 'when the hash consists of expressions' do
+      it 'returns an sql expression' do
+        expect(func.case(users[:id].is([1, 2]) => 'first', else: 'last').sql_literal(ds)).
+          to eql(%((CASE WHEN ("users"."id" IN (1, 2)) THEN 'first' ELSE 'last' END)))
       end
     end
   end

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -62,13 +62,6 @@ RSpec.describe ROM::SQL::Function, :postgres do
   end
 
   describe '#case' do
-    # context 'when additional expression is provided' do
-    #   it 'returns an sql expression' do
-    #     expect(func.case({ 1 => "first" }, "last", expr: users[:id]).sql_literal(ds))
-    #       .to eql(%((CASE "users"."id" WHEN 1 THEN 'first' ELSE 'last' END)))
-    #   end
-    # end
-
     context 'when condition argument is a Hash' do
       it 'returns an sql expression' do
         expect(func.case('1' => "first", else: "last").sql_literal(ds)).

--- a/spec/unit/projection_dsl_spec.rb
+++ b/spec/unit/projection_dsl_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe ROM::SQL::ProjectionDSL, :postgres, helpers: true do
 
       expect(literals).to eql([%(PG_ADVISORY_LOCK(1) AS "lock")])
     end
+
+    it 'supports building typed literals' do
+      schema = dsl.call { int(1).as(:one) }
+      literals = schema.map { |attr| attr.sql_literal(ds) }
+      attr = schema.to_a[0]
+
+      expect(literals).to eql([%(1 AS "one")])
+      expect(attr.type.to_ast(meta: false)).to eql(ROM::SQL::Types::Integer.to_ast)
+    end
   end
 
   describe '#method_missing' do


### PR DESCRIPTION
Based on https://github.com/rom-rb/rom-sql/pull/282

I reworked the syntax since I actually don't like the way it's implemented in Sequel. Now we have two versions of `#case` when `CASE`:

```ruby
# matching expression result
users.select_append { id.case(1 => `'one'`, else: `'something else'`).as(:one_or_else) }

# searching for `true` result
users.select_append { string::case(id.is(1) => 'one', else: 'else').as(:one_or_else) }
```

Note that `else:` is required in both cases (no pun intended) since Sequel enforces it.

I also added simplified syntax for using typed literal values for projections:

```ruby
users.select_append { num.case('one' => int(1), 'two' => int(2), else: int(0)).as(:num_int) }
```

Sorry for the delay I wanted to play with the code a bit.

/cc @wmaciejak 