### PR TITLE
Allow to project EXISTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,14 @@
   # searching for `true` result
   users.select_append { string::case(id.is(1) => 'one', else: 'else').as(:one_or_else) }
   ```
-* Relations can be accessed in DSLs with keyword arguments
+* Relations can be accessed in DSLs with keyword arguments (flash-gordon)
   ```ruby
   users.join(posts).select_append { |posts: | posts[:title] }
   ```
-
 * Support for `.exists` in the projection DSL (flash-gordon)
-
   ```ruby
-  users.select_append { |r|
-    exists(r[:posts].where(r[:posts][:user_id] => id)).as(:has_posts)
+  users.select_append { |posts: |
+    exists(posts.where(posts[:user_id] => id)).as(:has_posts)
   }
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
   users.join(posts).select_append { |posts: | posts[:title] }
   ```
 
+* Support for `.exists` in the projection DSL (flash-gordon)
+
+  ```ruby
+  users.select_append { |r|
+    exists(r[:posts].where(r[:posts][:user_id] => id)).as(:has_posts)
+  }
+  ```
+
 [Compare v2.5.0...master](https://github.com/rom-rb/rom-sql/compare/v2.5.0...master)
 
 ## v2.5.0 2018-06-08

--- a/lib/rom/sql/dsl.rb
+++ b/lib/rom/sql/dsl.rb
@@ -47,6 +47,17 @@ module ROM
         ::Sequel.lit(value)
       end
 
+      # Returns a result of SQL EXISTS clause.
+      #
+      # @example
+      #   users.where { exists(users.where(name: 'John')) }
+      #   users.select_append { |r| exists(r[:posts].where(r[:posts][:user_id] => id)).as(:has_posts) }
+      #
+      # @api public
+      def exists(relation)
+        ::ROM::SQL::Attribute[Types::Bool].meta(sql_expr: relation.dataset.exists)
+      end
+
       # @api private
       def respond_to_missing?(name, include_private = false)
         super || schema.key?(name)

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -39,6 +39,15 @@ module ROM
       end
       alias_method :f, :function
 
+      # Returns a result of SQL EXISTS clause.
+      #
+      # @example
+      #   users.where { exists(users.where(name: 'John')) }
+      #   users.select_append { |r| exists(r[:posts].where(r[:posts][:user_id] => id)).as(:has_posts) }
+      def exists(relation)
+        ::ROM::SQL::Attribute[Types::Bool].meta(sql_expr: relation.dataset.exists)
+      end
+
       # @api private
       def respond_to_missing?(name, include_private = false)
         super || type(name)

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -39,15 +39,6 @@ module ROM
       end
       alias_method :f, :function
 
-      # Returns a result of SQL EXISTS clause.
-      #
-      # @example
-      #   users.where { exists(users.where(name: 'John')) }
-      #   users.select_append { |r| exists(r[:posts].where(r[:posts][:user_id] => id)).as(:has_posts) }
-      def exists(relation)
-        ::ROM::SQL::Attribute[Types::Bool].meta(sql_expr: relation.dataset.exists)
-      end
-
       # @api private
       def respond_to_missing?(name, include_private = false)
         super || type(name)

--- a/lib/rom/sql/restriction_dsl.rb
+++ b/lib/rom/sql/restriction_dsl.rb
@@ -9,14 +9,6 @@ module ROM
         instance_exec(select_relations(block.parameters), &block)
       end
 
-      # Returns a result of SQL EXISTS clause.
-      #
-      # @example
-      #   users.where { exists(users.where(name: 'John')) }
-      def exists(relation)
-        ::ROM::SQL::Attribute[Types::Bool].meta(sql_expr: relation.dataset.exists)
-      end
-
       private
 
       # @api private

--- a/spec/unit/projection_dsl_spec.rb
+++ b/spec/unit/projection_dsl_spec.rb
@@ -109,6 +109,16 @@ RSpec.describe ROM::SQL::ProjectionDSL, :postgres, helpers: true do
       expect(literals).to eql([%(1 AS "one")])
       expect(attr.type.to_ast(meta: false)).to eql(ROM::SQL::Types::Integer.to_ast)
     end
+
+    it 'supports exists operator' do
+      rel = double(dataset: ds)
+      schema = dsl.call { |r| exists(rel).as(:subq) }
+      literals = schema.map { |attr| attr.sql_literal(ds) }
+      attr = schema.to_a[0]
+
+      expect(literals).to eql([%((EXISTS (SELECT * FROM "users")) AS "subq")])
+      expect(attr.type.to_ast(meta: false)).to eql(ROM::SQL::Types::Bool.to_ast)
+    end
   end
 
   describe '#method_missing' do


### PR DESCRIPTION
Allows this fancy syntax:
```ruby
users.select_append { |posts: |
  exists(posts.where(posts[:user_id] => id)).as(:has_posts)
}
```