### PR TITLE
Allow to install pry via Bundler under Truffleruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 group :test do
   gem 'pry-byebug', platforms: :mri
-  gem 'pry', platforms: %i(jruby rbx)
+  gem 'pry', platforms: %i(jruby rbx truffleruby)
   gem 'activesupport', '~> 5.0'
   gem 'codeclimate-test-reporter', require: false
   gem 'simplecov', require: false


### PR DESCRIPTION
Without this, the most specs fail on `cannot load such file -- pry` under Truffleruby.

This first baby step heading to Truffleruby support. Currently there are still some problems under Truffleruby.

But this PR can bring one issue. Bundler can recognize `truffleruby` since 1.16.5 and later. Unfortunately only for specs thought. See https://github.com/bundler/bundler/blob/v1.16.5/lib/bundler/current_ruby.rb
 