### PR TITLE
Add helpers to get first/last tuple index in page

### DIFF
--- a/lib/rom/sql/plugin/pagination.rb
+++ b/lib/rom/sql/plugin/pagination.rb
@@ -72,6 +72,26 @@ module ROM
             (total / per_page.to_f).ceil
           end
 
+          # Return one-based index of first tuple in page
+          #
+          # @return [Integer]
+          #
+          # @api public
+          def first_in_page
+            ((current_page - 1) * per_page) + 1
+          end
+
+          # Return one-based index of last tuple in page
+          #
+          # @return [Integer]
+          #
+          # @api public
+          def last_in_page
+            return total if current_page == total_pages
+
+            current_page * per_page
+          end
+
           # @api private
           def at(dataset, current_page, per_page = self.per_page)
             current_page = current_page.to_i

--- a/spec/unit/plugin/pagination_spec.rb
+++ b/spec/unit/plugin/pagination_spec.rb
@@ -74,17 +74,23 @@ RSpec.describe 'Plugin / Pagination', seeds: false do
         expect(users.pager.current_page).to be(1)
         expect(users.pager.next_page).to be(2)
         expect(users.pager.prev_page).to be(nil)
+        expect(users.pager.first_in_page).to eq(1)
+        expect(users.pager.last_in_page).to eq(4)
 
         users = container.relations[:users].page(2)
 
         expect(users.pager.current_page).to be(2)
         expect(users.pager.next_page).to be(3)
         expect(users.pager.prev_page).to be(1)
+        expect(users.pager.first_in_page).to eq(5)
+        expect(users.pager.last_in_page).to eq(8)
 
         users = container.relations[:users].page(3)
 
         expect(users.pager.next_page).to be(nil)
         expect(users.pager.prev_page).to be(2)
+        expect(users.pager.first_in_page).to eq(9)
+        expect(users.pager.last_in_page).to eq(9)
       end
     end
   end


### PR DESCRIPTION
This supports rendering the typical text of:

Showing from `<first>` to `<last>` of `<total>` records