### PR TITLE
[WIP] Fix aliased attributes sql literals

### DIFF
--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -275,20 +275,13 @@ module ROM
         Function.new(type).concat(self, sep, other)
       end
 
-      # Sequel calls this method to coerce an attribute into SQL string.
-      #
-      # If the attribute is aliased and it is on the right of the
-      # `FROM table` keyword, we need to use its canonical name.
+      # Sequel calls this method to coerce an attribute into SQL string
       #
       # @param [Sequel::Dataset] ds
       #
       # @api private
-      def sql_literal_append(ds, sql)
-        if aliased? && sql.match?(/ FROM ["`]#{source.dataset}["`] /)
-          canonical.sql_literal_append(ds, sql)
-        else
-          ds.literal_append(sql, sql_expr)
-        end
+      def sql_literal(ds)
+        ds.literal(sql_expr)
       end
 
       # Sequel column representation

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -275,13 +275,20 @@ module ROM
         Function.new(type).concat(self, sep, other)
       end
 
-      # Sequel calls this method to coerce an attribute into SQL string
+      # Sequel calls this method to coerce an attribute into SQL string.
+      #
+      # If the attribute is aliased and it is on the right of the
+      # `FROM table` keyword, we need to use its canonical name.
       #
       # @param [Sequel::Dataset] ds
       #
       # @api private
-      def sql_literal(ds)
-        ds.literal(sql_expr)
+      def sql_literal_append(ds, sql)
+        if aliased? && sql.match?(/ FROM ["`]#{source.dataset}["`] /)
+          canonical.sql_literal_append(ds, sql)
+        else
+          ds.literal_append(sql, sql_expr)
+        end
       end
 
       # Sequel column representation

--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -1031,6 +1031,8 @@ module ROM
             if k.is_a?(Symbol) && schema.canonical.key?(k)
               type = schema.canonical[k]
               h[k] = v.is_a?(Array) ? v.map { |e| type[e] } : type[v]
+            elsif k.is_a?(ROM::SQL::Attribute)
+              h[k.canonical] = v
             else
               h[k] = v
             end

--- a/spec/unit/relation/where_spec.rb
+++ b/spec/unit/relation/where_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe ROM::Relation, '#where' do
         expect(relation.rename(id: :user_id).where { id > 3 }.to_a).to be_empty
       end
 
+      it 'restricts relation using aliased attributes' do
+        aliased_relation = relation.rename(title: :task_title)
+
+        expect(aliased_relation.where(aliased_relation[:title] => "Jane's task").to_a).to eql([{ id: 2, task_title: "Jane's task" }])
+      end
+
       it 'restricts relation using attributes from another relation' do
         expect(relation.join(:users, id: :user_id).where { |r| r[:users][:name].is("Jane") }.to_a).
           to eql([{ id: 2, title: "Jane's task" }])

--- a/spec/unit/relation/where_spec.rb
+++ b/spec/unit/relation/where_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ROM::Relation, '#where' do
         expect(relation.rename(id: :user_id).where { id > 3 }.to_a).to be_empty
       end
 
-      it 'restricts relation using aliased attributes' do
+      it 'restricts relation using aliased attributes as hash keys' do
         aliased_relation = relation.rename(title: :task_title)
 
         expect(aliased_relation.where(aliased_relation[:title] => "Jane's task").to_a).to eql([{ id: 2, task_title: "Jane's task" }])


### PR DESCRIPTION
References #316

This is still a WIP to fix referenced bug: tests are missing and some
previous have been broken. A more comprehensive solution needs to be
found, so I ask for any feedback or help.

When sequel creates a sql expression from an object, it tries to call
one the two following methods in this order:

- `sql_literal_append`
- `sql_literal`

rom-sql is implementing `sql_literal`, which only takes as argument the
sequel datastore. However, `sql_literal_append` takes two arguments: the
datastore and the sql string built so far.

The partial solution implemented in this commit matches the sql string
at the moment of invocation in order to detect whether we are to the
left of the `FROM table` clause or to the right of it. If we are to the
left we are referencing a column from the `SELECT` clause, so we keep
appending `name AS alias`. However, if we are to the right, what we need
is the canonical sql literal representation (i.e. `WHERE name = 1`).

This is obviously very hacky. I haven't found any way to inspect the
dataset or any other component in order to have a solid knowledge about
which sql clause is being constructed. So I'm afraid it could be the
only possible fix.

In case something in the same vein of this solution is to be
implemented, we should think the most comprehensive way to match the sql
query built so far. For example, the current solution would not work for
an `UPDATE table SET name as alias = 1...` statement. We should also
study whether it could break edge corner cases, like a column name
containing `FROM table` in its name.