### PR TITLE
Fix mapper compiler reading attribute alias

### DIFF
--- a/lib/rom/sql/mapper_compiler.rb
+++ b/lib/rom/sql/mapper_compiler.rb
@@ -4,10 +4,10 @@ module ROM
   module SQL
     class MapperCompiler < ROM::MapperCompiler
       def visit_attribute(node)
-        name, _, meta = node
+        name, _, meta_options = node
 
-        if meta[:wrapped]
-          [name, from: self.alias]
+        if meta_options[:wrapped]
+          [name, from: meta_options[:alias]]
         else
           [name]
         end


### PR DESCRIPTION
After merging #324 to master, `rom` test suite (once `rom-sql`
dependency was updated to the new master ref) was failing due to a change
introduced by error on reading the attribute alias from the mapper
compiler.