### PR TITLE
Add ROM::SQL::Relation#nullify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
+## Unreleased
+
+### Added
+
+- Support for `.nullify` on a relation for easier usage of the null-object
+  pattern (@ianks)
+  ```ruby
+  users.nullify.count # => will always be 0
+  users.nullify.to_a # => will always be empty ([])
+  ```
+
+[Compare v3.0.1...master](https://github.com/rom-rb/rom-sql/compare/v3.0.0...master)
+
 ## 3.0.1 2019-05-05
 
 ### Fixed
 
-* Using joins with a relation object as the target and a block-based conditions produces correct query now (issue #331) (solnic)
+- Using joins with a relation object as the target and a block-based conditions produces correct query now (issue #331) (solnic)
 
 [Compare v3.0.0...v3.0.1](https://github.com/rom-rb/rom-sql/compare/v3.0.0...v3.0.1)
 
@@ -10,7 +23,7 @@
 
 ### Added
 
-* Join DSL so that you can use arbitrary conditions when joining relations (flash-gordon)
+- Join DSL so that you can use arbitrary conditions when joining relations (flash-gordon)
   ```ruby
   users.join(tasks) { |users:, tasks:|
     tasks[:user_id].is(users[:id]) & users[:name].is('John')
@@ -24,7 +37,8 @@
     users[:id].is(authors[:id])
   }.select(:name)
   ```
-* Support for `CASE` expression (wmaciejak + flash-gordon)
+- Support for `CASE` expression (wmaciejak + flash-gordon)
+
   ```ruby
   # matching expression result
   users.select_append { id.case(1 => string('one'), else: string('something else')).as(:one_or_else) }
@@ -32,31 +46,34 @@
   # searching for `true` result
   users.select_append { string::case(id.is(1) => 'one', else: 'else').as(:one_or_else) }
   ```
-* Relations can be accessed in DSLs with keyword arguments (flash-gordon)
+
+- Relations can be accessed in DSLs with keyword arguments (flash-gordon)
   ```ruby
   users.join(posts).select_append { |posts: | posts[:title] }
   ```
-* Support for `.exists` in the projection DSL (flash-gordon)
+- Support for `.exists` in the projection DSL (flash-gordon)
   ```ruby
   users.select_append { |posts: |
     exists(posts.where(posts[:user_id] => id)).as(:has_posts)
   }
   ```
- * `Relation#unfiltered` returns an unrestricted relation (removes restrictions from `WHERE` and `HAVING`) (flash-gordon)
- * Support for `WITHIN GROUP` in the function DSL has been enhanced with block syntax (flash-gordon)
- ```ruby
-  # previously available version
-  households.project { float::percentile_cont(0.5).within_group(income).as(:percentile) }
-  # using the new syntax
-  households.project { float::percentile_cont(0.5).within_group { income }.as(:percentile) }
-  ```
- * Support for migrator options ie `ROM::Configuration.new(:sql, migrator: { path: "my_migrations" })` (rawburt)
- * `Relation#pluck` works with multiple args too (timriley)
+- `Relation#unfiltered` returns an unrestricted relation (removes restrictions from `WHERE` and `HAVING`) (flash-gordon)
+- Support for `WITHIN GROUP` in the function DSL has been enhanced with block syntax (flash-gordon)
+
+```ruby
+ # previously available version
+ households.project { float::percentile_cont(0.5).within_group(income).as(:percentile) }
+ # using the new syntax
+ households.project { float::percentile_cont(0.5).within_group { income }.as(:percentile) }
+```
+
+- Support for migrator options ie `ROM::Configuration.new(:sql, migrator: { path: "my_migrations" })` (rawburt)
+- `Relation#pluck` works with multiple args too (timriley)
 
 ### Changed
 
-* [BREAKING] Updated to work with `dry-types 1.0.0` (flash-gordon)
-* [BREAKING] `Types::Int` is now `Types::Integer` (GustavoCaso)
+- [BREAKING] Updated to work with `dry-types 1.0.0` (flash-gordon)
+- [BREAKING] `Types::Int` is now `Types::Integer` (GustavoCaso)
 
 ### Fixed
 
@@ -69,7 +86,7 @@
 
 ### Added
 
-* Support for subqueries in `SELECT` and `WHERE` :tada: (flash-gordon)
+- Support for subqueries in `SELECT` and `WHERE` :tada: (flash-gordon)
   ```ruby
   tasks = relations[:tasks]
   users = relations[:users]
@@ -84,8 +101,8 @@
 
 ### Added
 
-* Support for functions with `Any` return type (GustavoCaso)
-* New `Relation#as_hash` method (GustavoCaso)
+- Support for functions with `Any` return type (GustavoCaso)
+- New `Relation#as_hash` method (GustavoCaso)
 
 [Compare v2.3.0...v2.4.0](https://github.com/rom-rb/rom-sql/compare/v2.3.0...v2.4.0)
 
@@ -93,18 +110,18 @@
 
 ### Added
 
-* Command's `:timestamp` plugin now supports passing options (GustavoCaso)
-* Configuration supports hash with connection options (Kjarrigan + solnic)
+- Command's `:timestamp` plugin now supports passing options (GustavoCaso)
+- Configuration supports hash with connection options (Kjarrigan + solnic)
 
 ### Fixed
 
-* Aliased attributes are handled correctly in PG's commands (cflipse)
-* Command extensions are properly applied in multi-adapter setups (solnic)
+- Aliased attributes are handled correctly in PG's commands (cflipse)
+- Command extensions are properly applied in multi-adapter setups (solnic)
 
 ### Internal
 
-* Custom SQL-specific mapper compiler was added, which is used starting from rom-core 4.1.0 (solnic)
-* Command's `:timestamp` plugin was removed, as it was moved to rom-core (GustavoCaso)
+- Custom SQL-specific mapper compiler was added, which is used starting from rom-core 4.1.0 (solnic)
+- Command's `:timestamp` plugin was removed, as it was moved to rom-core (GustavoCaso)
 
 [Compare v2.2.1...v2.3.0](https://github.com/rom-rb/rom-sql/compare/v2.2.1...v2.3.0)
 
@@ -112,8 +129,8 @@
 
 ### Fixed
 
-* Instrumentation works with all db interactions (not just queries that materialize relations) (solnic)
-* Typo in `MissingEnv` exception message (romatr)
+- Instrumentation works with all db interactions (not just queries that materialize relations) (solnic)
+- Typo in `MissingEnv` exception message (romatr)
 
 [Compare v2.2.0...v2.2.1](https://github.com/rom-rb/rom-sql/compare/v2.2.0...v2.2.1)
 
@@ -121,14 +138,14 @@
 
 ### Added
 
-* Relation registry is passed as an argument to DSL blocks (in `select`, `where`, `order` etc.), which enables syntax like `select { |r| [id, r.tasks[:title]] }` (solnic)
-* Support for self-referenced many-to-many associations (solnic)
-* PG's geometric types include meta data about db types (GustavoCaso)
+- Relation registry is passed as an argument to DSL blocks (in `select`, `where`, `order` etc.), which enables syntax like `select { |r| [id, r.tasks[:title]] }` (solnic)
+- Support for self-referenced many-to-many associations (solnic)
+- PG's geometric types include meta data about db types (GustavoCaso)
 
 ### Fixed
 
-* Custom schema is used correctly in command results (solnic)
-* Schemas no longer finalize PKs (this is done in core schema already) (solnic)
+- Custom schema is used correctly in command results (solnic)
+- Schemas no longer finalize PKs (this is done in core schema already) (solnic)
 
 [Compare v2.1.0...v2.2.0](https://github.com/rom-rb/rom-sql/compare/v2.1.0...v2.2.0)
 
@@ -136,15 +153,15 @@
 
 ### Added
 
-* Support for PG's range types (v-kolesnikov)
-* Support for PG's `ltree` (GustavoCaso + solnic)
-* Support for the `FILTER` clause (flash-gordon)
-* PG's array types will use custom types for processing members ie `ltree[]` will use `LTree` type (solnic)
+- Support for PG's range types (v-kolesnikov)
+- Support for PG's `ltree` (GustavoCaso + solnic)
+- Support for the `FILTER` clause (flash-gordon)
+- PG's array types will use custom types for processing members ie `ltree[]` will use `LTree` type (solnic)
 
 ### Fixed
 
-* Schema inference works with primary keys that have custom types (ie an enum PK column) (v-kolesnikov)
-* Ruby warnings are gone (solnic)
+- Schema inference works with primary keys that have custom types (ie an enum PK column) (v-kolesnikov)
+- Ruby warnings are gone (solnic)
 
 [Compare v2.0.0...v2.1.0](https://github.com/rom-rb/rom-sql/compare/v2.0.0...v2.1.0)
 
@@ -152,9 +169,9 @@
 
 ### Added
 
-* Support for schema plugins (flash-gordon)
-* Support for auto migrations (flash-gordon)
-* Add DLS for describing table indexes (flash-gordon)
+- Support for schema plugins (flash-gordon)
+- Support for auto migrations (flash-gordon)
+- Add DLS for describing table indexes (flash-gordon)
 
   ```ruby
     schema do
@@ -167,27 +184,27 @@
     end
   ```
 
-* Support for composite indexes in the auto-restrictions plugin (flash-gordon)
-* `SQL::Gateway#call` calls a SQL function (flash-gordon)
+- Support for composite indexes in the auto-restrictions plugin (flash-gordon)
+- `SQL::Gateway#call` calls a SQL function (flash-gordon)
 
   ```ruby
     gateway.(:upper, 'foo') # => "FOO"
     gateway.(:pg_advisory_xact_lock, 1234) # => nil
   ```
 
-* `SQL::Gateway#run` executes a SQL string, e.g. a DDL statement (flash-gordon)
+- `SQL::Gateway#run` executes a SQL string, e.g. a DDL statement (flash-gordon)
 
   ```ruby
     gateway.run('set session IntervalStyle to default')
   ```
 
-* `SQL::Relation#exists` joins a relation with the `EXISTS` operator (flash-gordon)
+- `SQL::Relation#exists` joins a relation with the `EXISTS` operator (flash-gordon)
 
   ```ruby
     users.exists(posts) # => users with posts
   ```
 
-* Support for processing a relation in batches (flash-gordon)
+- Support for processing a relation in batches (flash-gordon)
 
   ```ruby
     users.each_batch(size: 100) do |rel|
@@ -197,52 +214,51 @@
     end
   ```
 
-* `SQL::Relation#import` inserts data from another relation using the `INSERT ... AS SELECT` syntax which is often far more effective than row-by-row processing and an ordinary multi-insert. Relations defined on another gateway are also supported, and in this case, the implementation falls back to the multi-insert strategy (flash-gordon)
+- `SQL::Relation#import` inserts data from another relation using the `INSERT ... AS SELECT` syntax which is often far more effective than row-by-row processing and an ordinary multi-insert. Relations defined on another gateway are also supported, and in this case, the implementation falls back to the multi-insert strategy (flash-gordon)
 
   ```ruby
     users.import(authors.select { first_name.concat(last_name).as(:name) })
   ```
 
-* Support for `tinytext`, `text`, `mediumtext`, and `longtext data types in MySQL (panthomakos)
-* The new `pg_explain` plugin for getting query plans on PostgreSQL (flash-gordon)
+- Support for `tinytext`, `text`, `mediumtext`, and `longtext data types in MySQL (panthomakos)
+- The new `pg_explain` plugin for getting query plans on PostgreSQL (flash-gordon)
 
   ```ruby
     users.by_pk(1).explain(format: :json, analyze: true)
   ```
 
-* Support for window function calls
+- Support for window function calls
 
   ```ruby
     employees.select { [dep_no, salary, integer::avg(salary).over(partition: dep_no, order: id).as(:avg_salary)] }
   ```
 
-* Function result can be negated, also `ROM::SQL::Function#not` was added (flash-gordon)
+- Function result can be negated, also `ROM::SQL::Function#not` was added (flash-gordon)
 
   ```ruby
      users.where { !lower(name).is('John') }
      users.where { lower(name).not('John') }
   ```
 
-
 ### Changed
 
-* [BREAKING] based on rom 4.0 now (flash-gordon + solnic)
-* [BREAKING] `Associates` command plugin requires associations now (solnic)
-* [BREAKING] `Command#transaction` is gone in favor of `Relation#transaction` (solnic)
-* [BREAKING] `PG::JSONArray`, `PG::JSONBArray`, `PG::JSONHash`, and `PG::JSONBHash` types were dropped, use `PG::JSON` and `PG::JSONB` instead (flash-gordon)
-* [BREAKING] The `pg_hstore` extension now doesn't get loaded automatically, use the `:extension` option to load it on config initialization (flash-gordon)
-* `ManyToOne` no longer uses a join (solnic)
-* `AutoCombine` and `AutoWrap` plugins were removed as this functionality is provided by core API (solnic)
-* Foreign keys are indexed by default (flash-gordon)
-* Schemas are qualified by default (solnic)
-* `PG::JSON`, `PG::JSONB`, and `PG::Array` now all have read types so that they return plain Hash/Array values instead of Sequel's wrappers (flash-gordon)
+- [BREAKING] based on rom 4.0 now (flash-gordon + solnic)
+- [BREAKING] `Associates` command plugin requires associations now (solnic)
+- [BREAKING] `Command#transaction` is gone in favor of `Relation#transaction` (solnic)
+- [BREAKING] `PG::JSONArray`, `PG::JSONBArray`, `PG::JSONHash`, and `PG::JSONBHash` types were dropped, use `PG::JSON` and `PG::JSONB` instead (flash-gordon)
+- [BREAKING] The `pg_hstore` extension now doesn't get loaded automatically, use the `:extension` option to load it on config initialization (flash-gordon)
+- `ManyToOne` no longer uses a join (solnic)
+- `AutoCombine` and `AutoWrap` plugins were removed as this functionality is provided by core API (solnic)
+- Foreign keys are indexed by default (flash-gordon)
+- Schemas are qualified by default (solnic)
+- `PG::JSON`, `PG::JSONB`, and `PG::Array` now all have read types so that they return plain Hash/Array values instead of Sequel's wrappers (flash-gordon)
 
 ### Fixed
 
-* Self-ref associations work correctly with custom FKs (solnic)
-* Aliased associations with custom FKs work correctly (solnic)
-* Defining a custom dataset block no longer prevents default views like `by_pk` to be defined (solnic)
-* `Relation#group` uses canonical schema now (solnic)
+- Self-ref associations work correctly with custom FKs (solnic)
+- Aliased associations with custom FKs work correctly (solnic)
+- Defining a custom dataset block no longer prevents default views like `by_pk` to be defined (solnic)
+- `Relation#group` uses canonical schema now (solnic)
 
 [Compare v1.3.3...master](https://github.com/rom-rb/rom-sql/compare/v1.3.3...master)
 
@@ -250,15 +266,15 @@
 
 ### Added
 
-* `Relation#lock`, row-level locking using the `SELECT FOR UPDATE` clause (flash-gordon)
-* `get` and `get_text` methods for the `PG::JSON` type (flash-gordon)
-* Support for converting data type with `CAST` using the function DSL (flash-gordon)
+- `Relation#lock`, row-level locking using the `SELECT FOR UPDATE` clause (flash-gordon)
+- `get` and `get_text` methods for the `PG::JSON` type (flash-gordon)
+- Support for converting data type with `CAST` using the function DSL (flash-gordon)
 
   ```ruby
     users.select { string::cast(id, 'varchar').as(:id_str) }
   ```
 
-* Support for`EXISTS` (v-kolesnikov)
+- Support for`EXISTS` (v-kolesnikov)
 
   ```ruby
     subquery = tasks.where(tasks[:user_id].qualified => users[:id].qualified)
@@ -267,7 +283,7 @@
 
 ### Fixed
 
-* Fixed a regression introduced in v1.3.2 caused by doing way more work processing the default dataset (flash-gordon)
+- Fixed a regression introduced in v1.3.2 caused by doing way more work processing the default dataset (flash-gordon)
 
 [Compare v1.3.2...v1.3.3](https://github.com/rom-rb/rom-sql/compare/v1.3.2...v1.3.3)
 
@@ -275,13 +291,13 @@
 
 ### Added
 
-* Support for filtering with a SQL function in the `WHERE` clause. Be sure you're using it wisely and don't call it on large datasets ;) (flash-gordon)
-* `Void` type for calling functions without returning value (flash-gordon)
-* Support for [`PG::Array` transformations and queries](https://github.com/rom-rb/rom-sql/blob/15019a40e2cf2a224476184c4cddab4062a2cc01/lib/rom/sql/extensions/postgres/types.rb#L23-L148) (flash-gordon)
+- Support for filtering with a SQL function in the `WHERE` clause. Be sure you're using it wisely and don't call it on large datasets ;) (flash-gordon)
+- `Void` type for calling functions without returning value (flash-gordon)
+- Support for [`PG::Array` transformations and queries](https://github.com/rom-rb/rom-sql/blob/15019a40e2cf2a224476184c4cddab4062a2cc01/lib/rom/sql/extensions/postgres/types.rb#L23-L148) (flash-gordon)
 
 ### Fixed
 
-* A bunch of warnings from Sequel 4.46
+- A bunch of warnings from Sequel 4.46
 
 [Compare v1.3.1...v1.3.2](https://github.com/rom-rb/rom-sql/compare/v1.3.1...v1.3.2)
 
@@ -289,7 +305,7 @@
 
 ### Changed
 
-* [internal] Compatibility with `dry-core` v0.3.0 (flash-gordon)
+- [internal] Compatibility with `dry-core` v0.3.0 (flash-gordon)
 
 [Compare v1.3.0...v1.3.1](https://github.com/rom-rb/rom-sql/compare/v1.3.0...v1.3.1)
 
@@ -297,22 +313,22 @@
 
 ### Added
 
-* New `Relation#exist?` predicate checks if the relation has at least one tuple (flash-gordon)
-* Support for [JSONB transformations and queries](https://github.com/rom-rb/rom-sql/blob/15019a40e2cf2a224476184c4cddab4062a2cc01/lib/rom/sql/extensions/postgres/types.rb#L170-L353) using native DSL (flash-gordon)
-* Add `ROM::SQL::Attribute#not` for negated boolean equality expressions (AMHOL)
-* Add `ROM::SQL::Attribute#!` for negated attribute's sql expressions (solnic)
-* Inferrer gets limit constraints for string data types and stores them in type's meta (v-kolesnikov)
+- New `Relation#exist?` predicate checks if the relation has at least one tuple (flash-gordon)
+- Support for [JSONB transformations and queries](https://github.com/rom-rb/rom-sql/blob/15019a40e2cf2a224476184c4cddab4062a2cc01/lib/rom/sql/extensions/postgres/types.rb#L170-L353) using native DSL (flash-gordon)
+- Add `ROM::SQL::Attribute#not` for negated boolean equality expressions (AMHOL)
+- Add `ROM::SQL::Attribute#!` for negated attribute's sql expressions (solnic)
+- Inferrer gets limit constraints for string data types and stores them in type's meta (v-kolesnikov)
 
 ### Fixed
 
-* Fixed usage of PostgreSQL's commands with a composite relation (flash-gordon)
-* Translation of `true/false/nil` equality checks to `is/is not` SQL statements in `ROM::SQL::Attribute#is` (AMHOL)
-* `associates` command plugin coerces parent collections to hashes correctly (aarek+solnic)
-* `by_pk` works correctly even when PK is not projected (solnic)
+- Fixed usage of PostgreSQL's commands with a composite relation (flash-gordon)
+- Translation of `true/false/nil` equality checks to `is/is not` SQL statements in `ROM::SQL::Attribute#is` (AMHOL)
+- `associates` command plugin coerces parent collections to hashes correctly (aarek+solnic)
+- `by_pk` works correctly even when PK is not projected (solnic)
 
 ### Changed
 
-* Global private interface `SQL::Gateway.instance` has been deprecated. Now if you run migrations
+- Global private interface `SQL::Gateway.instance` has been deprecated. Now if you run migrations
   with ROM you should set up a ROM config in the `db:setup` task with something similar to
 
   ```ruby
@@ -329,7 +345,7 @@
 
 ### Changed
 
-* Updated `dry-initializer` (flash-gordon)
+- Updated `dry-initializer` (flash-gordon)
 
 [Compare v1.2.1...v1.2.2](https://github.com/rom-rb/rom-sql/compare/v1.2.1...v1.2.2)
 
@@ -337,7 +353,7 @@
 
 ### Fixed
 
-* Allow for joining by a `RelationProxy` instance from `rom-repository` (davydovanton)
+- Allow for joining by a `RelationProxy` instance from `rom-repository` (davydovanton)
 
 [Compare v1.2.0...v1.2.1](https://github.com/rom-rb/rom-sql/compare/v1.2.0...v1.2.1)
 
@@ -345,9 +361,9 @@
 
 ### Added
 
-* Support for configuring multiple associations for a command (solnic)
-* Support for passing parent tuple(s) as `parent` option in `Command#with_association` (solnic)
-* Support for join using assocation name (flash-gordon)
+- Support for configuring multiple associations for a command (solnic)
+- Support for passing parent tuple(s) as `parent` option in `Command#with_association` (solnic)
+- Support for join using assocation name (flash-gordon)
 
 [Compare v1.1.2...v1.2.0](https://github.com/rom-rb/rom-sql/compare/v1.1.2...v1.2.0)
 
@@ -355,7 +371,7 @@
 
 ### Fixed
 
-* Fix grouping by a function in the block DSL (flash-gordon)
+- Fix grouping by a function in the block DSL (flash-gordon)
 
 [Compare v1.1.1...v1.1.2](https://github.com/rom-rb/rom-sql/compare/v1.1.1...v1.1.2)
 
@@ -363,7 +379,7 @@
 
 ### Fixed
 
-* Restriction conditions with an array as a value are handled correctly by attribute types (solnic)
+- Restriction conditions with an array as a value are handled correctly by attribute types (solnic)
 
 [Compare v1.1.0...v1.1.1](https://github.com/rom-rb/rom-sql/compare/v1.1.0...v1.1.1)
 
@@ -371,15 +387,15 @@
 
 ### Added
 
-* Added inferring for database indices (flash-gordon)
-* Restriction conditions are now coerced using schema attributes (solnic)
-* `:instrumentation` relation plugin that can be configured with any instrumentation backend (solnic)
-* `:auto_restrictions` relation plugin, which defines `by_*` views restricting relations by their indexed attributes (solnic)
+- Added inferring for database indices (flash-gordon)
+- Restriction conditions are now coerced using schema attributes (solnic)
+- `:instrumentation` relation plugin that can be configured with any instrumentation backend (solnic)
+- `:auto_restrictions` relation plugin, which defines `by_*` views restricting relations by their indexed attributes (solnic)
 
 ### Fixed
 
-* Missing `group` method was added to legacy `SequelAPI` module (solnic)
-* Associations properly maintain `order` if it was set (solnic)
+- Missing `group` method was added to legacy `SequelAPI` module (solnic)
+- Associations properly maintain `order` if it was set (solnic)
 
 [Compare v1.0.3...v1.1.0](https://github.com/rom-rb/rom-sql/compare/v1.0.3...v1.1.0)
 
@@ -387,11 +403,11 @@
 
 ### Changed
 
-* `AutoCombine#preload` uses better restriction for `ManyToOne` association which greatly speeds up loading bigger amounts of data (solnic + flash-gordon)
+- `AutoCombine#preload` uses better restriction for `ManyToOne` association which greatly speeds up loading bigger amounts of data (solnic + flash-gordon)
 
 ### Fixed
 
-* Fix the usage of timestamp in command chains (cflipse)
+- Fix the usage of timestamp in command chains (cflipse)
 
 [Compare v1.0.2...v1.0.3](https://github.com/rom-rb/rom-sql/compare/v1.0.2...v1.0.3)
 
@@ -399,7 +415,7 @@
 
 ### Added
 
-* Support for selecting literal strings via ``select { `'foo'`.as(:bar) }`` (solnic)
+- Support for selecting literal strings via `` select { `'foo'`.as(:bar) } `` (solnic)
 
 [Compare v1.0.1...v1.0.2](https://github.com/rom-rb/rom-sql/compare/v1.0.1...v1.0.2)
 
@@ -407,14 +423,14 @@
 
 ### Added
 
-* Support for inferring the PostgreSQL `hstore` data type (flash-gordon)
-* Support for the rest of geometric PostgreSQL data types (box, lseg, polygon, etc.) (Morozzzko)
-* Added inferring for timestamp types with specified precision (flash-gordon)
-* Added `ROM::SQL::Attribute#in` to support range checks in conditions (flash-gordon)
+- Support for inferring the PostgreSQL `hstore` data type (flash-gordon)
+- Support for the rest of geometric PostgreSQL data types (box, lseg, polygon, etc.) (Morozzzko)
+- Added inferring for timestamp types with specified precision (flash-gordon)
+- Added `ROM::SQL::Attribute#in` to support range checks in conditions (flash-gordon)
 
 ### Fixed
 
-* Missing primary key now leads to a more meaningful error (flash-gordon)
+- Missing primary key now leads to a more meaningful error (flash-gordon)
 
 [Compare v1.0.0...v1.0.1](https://github.com/rom-rb/rom-sql/compare/v1.0.0...v1.0.1)
 
@@ -426,37 +442,37 @@ Please refer to [the upgrading guide](https://github.com/rom-rb/rom-sql/wiki/Upg
 
 ### Added
 
-* [BREAKING] All relations have schemas (inferred by default, but still possible to override and/or extend) (solnic)
-* [BREAKING] Schemas are used when defining relation views (solnic)
-* [BREAKING] Default dataset is set up based on schema (solnic)
-* Extended query API with support for schema attributes (solnic)
-* Schemas can project relations automatically (solnic)
-* New `Schema#qualified` (solnic)
-* New `Relation#assoc` method which is a shortcut for accessing relation created by the given association (solnic)
-* Schema attribute types are now SQL-specific and compatible with query DSL (ie you can pass relation attributes to `select` and they will be automatically converted to valid SQL expressions) (solnic)
-* Associations support setting custom `view` that will be used to extend association relation (solnic)
-* Associations support setting custom `foreign_key` names (solnic)
-* Update commands has `:associates` plugin enabled (solnic)
-* Support for self-referencing associations (ie categories have_many child categories) (solnic)
-* Inferrers for mysql and sqlite were added (flash-gordon)
-* PG's auto-inferrer can handle `inet`/`cidr`/`point` data types in a two-way manner, i.e. converting them back and forth on reading and writing (flash-gordon)
-* Support for inferring more PG types: `macaddr`, `xml` (flash-gordon)
-* `ROM::SQL::Relation::SequelAPI` extension for backward-compatible query API (this will be deprecated in 1.1.0 and removed in 2.0.0) (solnic)
-* Added `Object` type for `SQLite` which is used by the inferrer for columns without a type affinity (flash-gordon)
-* Support for composite PKs in the default `by_pk` view (solnic)
+- [BREAKING] All relations have schemas (inferred by default, but still possible to override and/or extend) (solnic)
+- [BREAKING] Schemas are used when defining relation views (solnic)
+- [BREAKING] Default dataset is set up based on schema (solnic)
+- Extended query API with support for schema attributes (solnic)
+- Schemas can project relations automatically (solnic)
+- New `Schema#qualified` (solnic)
+- New `Relation#assoc` method which is a shortcut for accessing relation created by the given association (solnic)
+- Schema attribute types are now SQL-specific and compatible with query DSL (ie you can pass relation attributes to `select` and they will be automatically converted to valid SQL expressions) (solnic)
+- Associations support setting custom `view` that will be used to extend association relation (solnic)
+- Associations support setting custom `foreign_key` names (solnic)
+- Update commands has `:associates` plugin enabled (solnic)
+- Support for self-referencing associations (ie categories have_many child categories) (solnic)
+- Inferrers for mysql and sqlite were added (flash-gordon)
+- PG's auto-inferrer can handle `inet`/`cidr`/`point` data types in a two-way manner, i.e. converting them back and forth on reading and writing (flash-gordon)
+- Support for inferring more PG types: `macaddr`, `xml` (flash-gordon)
+- `ROM::SQL::Relation::SequelAPI` extension for backward-compatible query API (this will be deprecated in 1.1.0 and removed in 2.0.0) (solnic)
+- Added `Object` type for `SQLite` which is used by the inferrer for columns without a type affinity (flash-gordon)
+- Support for composite PKs in the default `by_pk` view (solnic)
 
 ### Changed
 
-* [BREAKING] `Relation#header` has been removed in favor of schemas (solnic)
-* [BREAKING] `Relation#base` has been removed as now a vanilla relation *is a base relation view* (solnic)
-* [BREAKING] Deprecated `Relation.primary_key` has been removed in favor of schema (solnic)
-* [BREAKING] Deprecated `Commands::Update#change` has been removed (solnic)
-* [BREAKING] Deprecated `Commands.validator` has been removed (solnic)
-* [BREAKING] `assoc_macros` plugin has been removed, please use associations from now (solnic)
-* Default `by_pk` uses schema attributes, it will raise exception if PK attribute is missing in the schema (solnic)
-* [internal] Associations use schemas for relation projections (solnic)
-* [internal] `select`, `select_append`, `project`, `inner_join` and `left_join` use schemas internally (solnic)
-* [internal] Deprecation and constants are now based on dry-core (flash-gordon)
+- [BREAKING] `Relation#header` has been removed in favor of schemas (solnic)
+- [BREAKING] `Relation#base` has been removed as now a vanilla relation _is a base relation view_ (solnic)
+- [BREAKING] Deprecated `Relation.primary_key` has been removed in favor of schema (solnic)
+- [BREAKING] Deprecated `Commands::Update#change` has been removed (solnic)
+- [BREAKING] Deprecated `Commands.validator` has been removed (solnic)
+- [BREAKING] `assoc_macros` plugin has been removed, please use associations from now (solnic)
+- Default `by_pk` uses schema attributes, it will raise exception if PK attribute is missing in the schema (solnic)
+- [internal] Associations use schemas for relation projections (solnic)
+- [internal] `select`, `select_append`, `project`, `inner_join` and `left_join` use schemas internally (solnic)
+- [internal] Deprecation and constants are now based on dry-core (flash-gordon)
 
 [Compare v0.9.1...v1.0.0](https://github.com/rom-rb/rom-sql/compare/v0.9.1...v1.0.0)
 
@@ -464,8 +480,8 @@ Please refer to [the upgrading guide](https://github.com/rom-rb/rom-sql/wiki/Upg
 
 ### Added
 
-* Support for PG enums in schema inferrer (flash-gordon)
-* `ROM::SQL::Relation#read` method which accepts an SQL string and returns a new relation (solnic)
+- Support for PG enums in schema inferrer (flash-gordon)
+- `ROM::SQL::Relation#read` method which accepts an SQL string and returns a new relation (solnic)
 
 [Compare v0.9.0...v0.9.1](https://github.com/rom-rb/rom-sql/compare/v0.9.0...v0.9.1)
 
@@ -473,22 +489,22 @@ Please refer to [the upgrading guide](https://github.com/rom-rb/rom-sql/wiki/Upg
 
 ### Added
 
-* `Associations::{OneToMany,OneToOne}#associate` for merging FKs into child tuple (jodosha)
-* Added support for PostgreSQL types: UUID, Array, JSONB and Money (jodosha)
-* Support for DB specific schema inferrers (flash-gordon)
-* Automatically infer PG arrays and JSON(B) types (jodosha + flash-gordon)
-* Support for `Relation#having` (cflipse)
+- `Associations::{OneToMany,OneToOne}#associate` for merging FKs into child tuple (jodosha)
+- Added support for PostgreSQL types: UUID, Array, JSONB and Money (jodosha)
+- Support for DB specific schema inferrers (flash-gordon)
+- Automatically infer PG arrays and JSON(B) types (jodosha + flash-gordon)
+- Support for `Relation#having` (cflipse)
 
 ### Changed
 
-* Inferred types in schemas **are no longer strict** (flash-gordon)
-* PG-specific types are handled by `:postgres` extension and it loads connection extensions automatically (flash-gordon)
-* Make `OneToOne` inherit from `OneToMany` (beauby)
-* Default dataset will use column names from schema if it's available (solnic)
+- Inferred types in schemas **are no longer strict** (flash-gordon)
+- PG-specific types are handled by `:postgres` extension and it loads connection extensions automatically (flash-gordon)
+- Make `OneToOne` inherit from `OneToMany` (beauby)
+- Default dataset will use column names from schema if it's available (solnic)
 
 ### Fixed
 
-* Floats are inferred by schemas (cflipse)
+- Floats are inferred by schemas (cflipse)
 
 [Compare v0.8.0...v0.9.0](https://github.com/rom-rb/rom-sql/compare/v0.8.0...v0.9.0)
 
@@ -496,27 +512,27 @@ Please refer to [the upgrading guide](https://github.com/rom-rb/rom-sql/wiki/Upg
 
 ### Added
 
-* Support for relation schemas with SQL-specific data types (solnic + flash-gordon)
-* One-To-Many support in schemas (solnic + flash-gordon)
-* One-To-One support in schemas (solnic + flash-gordon)
-* One-To-One-Through support in schemas (solnic + flash-gordon)
-* Many-To-One support in schemas (solnic + flash-gordon)
-* Many-To-Many support in schemas (solnic + flash-gordon)
-* Support for `has_many`, `has_one` and `belongs_to` convenient methods in schema DSL (solnic)
-* Support for custom PG types: `Types::PG::Array`, `Types::PG::Hash`, `Types::PG::JSON`, and `Types::PG::Bytea` (solnic + flash-gordon)
-* Optional automatic schema inference for attributes and foreign keys based on DB metadata provided by Sequel (flash-gordon)
-* Support for arbitrary dataset and FK names in schemas (flash-gordon)
-* Support for native upserts in PostgreSQL >= 9.5 via `Commands::Postgres::Upsert` (gotar + flash-gordon)
+- Support for relation schemas with SQL-specific data types (solnic + flash-gordon)
+- One-To-Many support in schemas (solnic + flash-gordon)
+- One-To-One support in schemas (solnic + flash-gordon)
+- One-To-One-Through support in schemas (solnic + flash-gordon)
+- Many-To-One support in schemas (solnic + flash-gordon)
+- Many-To-Many support in schemas (solnic + flash-gordon)
+- Support for `has_many`, `has_one` and `belongs_to` convenient methods in schema DSL (solnic)
+- Support for custom PG types: `Types::PG::Array`, `Types::PG::Hash`, `Types::PG::JSON`, and `Types::PG::Bytea` (solnic + flash-gordon)
+- Optional automatic schema inference for attributes and foreign keys based on DB metadata provided by Sequel (flash-gordon)
+- Support for arbitrary dataset and FK names in schemas (flash-gordon)
+- Support for native upserts in PostgreSQL >= 9.5 via `Commands::Postgres::Upsert` (gotar + flash-gordon)
 
 ### Changed
 
-* `Create` and `Update` commands have `:schema` plugin enabled by default which sets input handler based on schema definition automatically (solnic)
-* `associates` command plugin uses schema associations now (solnic)
-* Dropped MRI 2.0.x support
+- `Create` and `Update` commands have `:schema` plugin enabled by default which sets input handler based on schema definition automatically (solnic)
+- `associates` command plugin uses schema associations now (solnic)
+- Dropped MRI 2.0.x support
 
 ### Fixed
 
-* `Create` command properly materialize result when `:one` is set (AMHOL)
+- `Create` command properly materialize result when `:one` is set (AMHOL)
 
 [Compare v0.7.0...v0.8.0](https://github.com/rom-rb/rom-sql/compare/v0.7.0...v0.8.0)
 
@@ -524,26 +540,26 @@ Please refer to [the upgrading guide](https://github.com/rom-rb/rom-sql/wiki/Upg
 
 ### Added
 
-* Repository plugins have been imported:
-  * `view` allows defining a relation view with an explicit header (solnic)
-  * `base_view` defines a base view with all column names as the header (solnic)
-  * `auto_combine` defines a generic `for_combine` method which eager-loads
+- Repository plugins have been imported:
+  - `view` allows defining a relation view with an explicit header (solnic)
+  - `base_view` defines a base view with all column names as the header (solnic)
+  - `auto_combine` defines a generic `for_combine` method which eager-loads
     parent/children relation (solnic)
-  * `auto-wrap` defines a generic `for_wrap` method which inner-joins
+  - `auto-wrap` defines a generic `for_wrap` method which inner-joins
     a parent/children relation (solnic)
-* Possibility to check for pending migrations (gotar)
-* `Relation#sum` interface (gotar)
-* `Relation#avg` interface (gotar)
-* `Relation#min` interface (gotar)
-* `Relation#max` interface (gotar)
-* `Relation#union` interface (spscream)
-* `primary_key` macro which allows setting a custom primary key when it cannot be
-   inferred automatically (solnic)
+- Possibility to check for pending migrations (gotar)
+- `Relation#sum` interface (gotar)
+- `Relation#avg` interface (gotar)
+- `Relation#min` interface (gotar)
+- `Relation#max` interface (gotar)
+- `Relation#union` interface (spscream)
+- `primary_key` macro which allows setting a custom primary key when it cannot be
+  inferred automatically (solnic)
 
 ### Changed
 
-* `ROM::SQL.gateway` renamed to `ROM::SQL::Gateway.instance` for migrations (endash)
-* Association macros are now an optional plugin (solnic)
+- `ROM::SQL.gateway` renamed to `ROM::SQL::Gateway.instance` for migrations (endash)
+- Association macros are now an optional plugin (solnic)
 
 [Compare v0.6.1...v0.7.0](https://github.com/rom-rb/rom-sql/compare/v0.6.1...v0.7.0)
 
@@ -551,7 +567,7 @@ Please refer to [the upgrading guide](https://github.com/rom-rb/rom-sql/wiki/Upg
 
 ### Added
 
-* `Gateway` accepts `:extensions` as an option (c0)
+- `Gateway` accepts `:extensions` as an option (c0)
 
 [Compare v0.6.0...v0.6.1](https://github.com/rom-rb/rom-sql/compare/v0.6.0...v0.6.1)
 
@@ -565,15 +581,15 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* `Relation#multi_insert` (draxxxeus)
+- `Relation#multi_insert` (draxxxeus)
 
 ### Changed
 
-* Command that receives many tuples will use `multi_insert` now (draxxxeus)
+- Command that receives many tuples will use `multi_insert` now (draxxxeus)
 
 ### Fixed
 
-* Relation name and join key fixes for `many_to_one` macro (jamesmoriarty)
+- Relation name and join key fixes for `many_to_one` macro (jamesmoriarty)
 
 [Compare v0.5.2...v0.5.3](https://github.com/rom-rb/rom-sql/compare/v0.5.2...v0.5.3)
 
@@ -581,12 +597,12 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* `Relation#invert` operation (nepalez)
+- `Relation#invert` operation (nepalez)
 
 ### Changed
 
-* Migration tasks no longer require entire ROM env (solnic)
-* `Repository` => `Gateway` rename for ROM 0.8.0 compatibility (solnic)
+- Migration tasks no longer require entire ROM env (solnic)
+- `Repository` => `Gateway` rename for ROM 0.8.0 compatibility (solnic)
 
 [Compare v0.5.1...v0.5.2](https://github.com/rom-rb/rom-sql/compare/v0.5.1...v0.5.2)
 
@@ -594,11 +610,11 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Changed
 
-* Relations won't be finalized when table(s) is/are missing (solnic)
+- Relations won't be finalized when table(s) is/are missing (solnic)
 
 ### Fixed
 
-* Wrap errors when calling commands with `[]`-syntax (kwando)
+- Wrap errors when calling commands with `[]`-syntax (kwando)
 
 [Compare v0.5.0...v0.5.1](https://github.com/rom-rb/rom-sql/compare/v0.5.0...v0.5.1)
 
@@ -606,20 +622,20 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* Association macros support addition `:on` option (solnic)
-* `associates` plugin for `Create` command (solnic)
-* Support for NotNullConstraintError (solnic)
-* Support for UniqueConstraintConstraintError (solnic)
-* Support for ForeignKeyConstraintError (solnic)
-* Support for CheckConstraintError (solnic)
-* `Commands::Update#original` supports objects coercible to_h now (solnic)
+- Association macros support addition `:on` option (solnic)
+- `associates` plugin for `Create` command (solnic)
+- Support for NotNullConstraintError (solnic)
+- Support for UniqueConstraintConstraintError (solnic)
+- Support for ForeignKeyConstraintError (solnic)
+- Support for CheckConstraintError (solnic)
+- `Commands::Update#original` supports objects coercible to_h now (solnic)
 
 ### Changed
 
-* [BREAKING] Constraint errors are no longer command errors which means `try` and
+- [BREAKING] Constraint errors are no longer command errors which means `try` and
   `transaction` blocks will not catch them (solnic)
-* `Commands::Update#set` has been deprecated (solnic)
-* `Commands::Update#to` has been deprecated (solnic)
+- `Commands::Update#set` has been deprecated (solnic)
+- `Commands::Update#to` has been deprecated (solnic)
 
 [Compare v0.4.3...v0.5.0](https://github.com/rom-rb/rom-sql/compare/v0.4.2...v0.5.0)
 
@@ -627,7 +643,7 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Fixed
 
-* `transaction` doesn't swallow errors now other than CommandError (solnic)
+- `transaction` doesn't swallow errors now other than CommandError (solnic)
 
 [Compare v0.4.2...v0.4.3](https://github.com/rom-rb/rom-sql/compare/v0.4.2...v0.4.3)
 
@@ -635,19 +651,19 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* Support for setting custom association name (solnic)
-* Support for `:conditions` option in association definition (solnic)
-* Better error message when accessing undefined associations (pdswan)
+- Support for setting custom association name (solnic)
+- Support for `:conditions` option in association definition (solnic)
+- Better error message when accessing undefined associations (pdswan)
 
 ### Fixed
 
-* Correct `ROM::SQL::Plugin::Pagination::Pager#total_pages` when total is not
+- Correct `ROM::SQL::Plugin::Pagination::Pager#total_pages` when total is not
   evenly divisible by page size (larribas)
-* `association_join` behaves correctly when dataset is different than register_as (nepalez)
+- `association_join` behaves correctly when dataset is different than register_as (nepalez)
 
 ### Changed
 
-* `transaction` returns command failure objects when there was a rollback (solnic)
+- `transaction` returns command failure objects when there was a rollback (solnic)
 
 [Compare v0.4.1...v0.4.2](https://github.com/rom-rb/rom-sql/compare/v0.4.1...v0.4.2)
 
@@ -655,8 +671,8 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* Database error handling for update and delete commands (kwando + solnic)
-* Migration interface as a repository plugin (gotar + solnic)
+- Database error handling for update and delete commands (kwando + solnic)
+- Migration interface as a repository plugin (gotar + solnic)
 
 [Compare v0.4.0...v0.4.1](https://github.com/rom-rb/rom-sql/compare/v0.4.0...v0.4.1)
 
@@ -664,20 +680,20 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* `ROM::SQL::Relation` which explictly defines an interface on top of Sequel (solnic + mcls)
-* Postgres-specific Create and Update commands that support RETURNING (gotar + solnic)
-* `Update#change` interface for skipping execution when there's no diff (solnic)
-* Experimental migration API using sequel/migrations (gotar)
-* Pagination plugin (solnic)
-* Allow reuse of established Sequel connections (splattael)
+- `ROM::SQL::Relation` which explictly defines an interface on top of Sequel (solnic + mcls)
+- Postgres-specific Create and Update commands that support RETURNING (gotar + solnic)
+- `Update#change` interface for skipping execution when there's no diff (solnic)
+- Experimental migration API using sequel/migrations (gotar)
+- Pagination plugin (solnic)
+- Allow reuse of established Sequel connections (splattael)
 
 ### Changed
 
-* Use ROM's own inflector which uses either ActiveSupport or Inflecto backends (mjtko)
+- Use ROM's own inflector which uses either ActiveSupport or Inflecto backends (mjtko)
 
 ### Fixed
 
-* Indentation in Rails logger (morgoth)
+- Indentation in Rails logger (morgoth)
 
 [Compare v0.3.2...v0.4.0](https://github.com/rom-rb/rom-sql/compare/v0.3.2...v0.4.0)
 
@@ -685,7 +701,7 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Fixed
 
-* Checking tuple count in commands (solnic)
+- Checking tuple count in commands (solnic)
 
 [Compare v0.3.1...v0.3.2](https://github.com/rom-rb/rom-sql/compare/v0.3.1...v0.3.2)
 
@@ -693,8 +709,8 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* `Adapter#disconnect` (solnic)
-* Support for extra connection options (solnic)
+- `Adapter#disconnect` (solnic)
+- Support for extra connection options (solnic)
 
 [Compare v0.3.0...v0.3.1](https://github.com/rom-rb/rom-sql/compare/v0.3.0...v0.3.1)
 
@@ -702,8 +718,8 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Changed
 
-* `association_join` now uses Sequel's `graph` interface which qualifies columns automatically (solnic)
-* Delete command returns deleted tuples (solnic)
+- `association_join` now uses Sequel's `graph` interface which qualifies columns automatically (solnic)
+- Delete command returns deleted tuples (solnic)
 
 [Compare v0.2.0...v0.3.0](https://github.com/rom-rb/rom-sql/compare/v0.2.0...v0.3.0)
 
@@ -711,9 +727,9 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Added
 
-* Command API (solnic)
-* Support for ActiveSupport::Notifications with a log subscriber (solnic)
-* New `ROM::SQL::Adapter#dataset?(name)` checking if a given table exists (solnic)
+- Command API (solnic)
+- Support for ActiveSupport::Notifications with a log subscriber (solnic)
+- New `ROM::SQL::Adapter#dataset?(name)` checking if a given table exists (solnic)
 
 [Compare v0.1.1...v0.2.0](https://github.com/rom-rb/rom-sql/compare/v0.1.1...v0.2.0)
 
@@ -721,11 +737,11 @@ Internal updates to fix deprecation warnings from ROM 0.9.0.
 
 ### Fixed
 
-* Equalizer in header (solnic)
+- Equalizer in header (solnic)
 
 ### Changed
 
-* minor refactor in adapter (solnic)
+- minor refactor in adapter (solnic)
 
 [Compare v0.1.0...v0.1.1](https://github.com/rom-rb/rom-sql/compare/v0.1.0...v0.1.1)
 

--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -234,6 +234,9 @@ module ROM
         # this will be default in Sequel 5.0.0 and since we don't rely
         # on dataset mutation it is safe to enable it already
         connection.extension(:freeze_datasets) unless RUBY_ENGINE == 'rbx'
+
+        # for ROM::SQL::Relation#nullify
+        connection.extension(:null_dataset)
       end
 
       # @api private

--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -1002,6 +1002,20 @@ module ROM
           new(dataset.__send__(__method__))
         end
 
+        # Returns a relation that will never issue a query to the database. It
+        # implements the null object pattern for relations.
+        #
+        # @see http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/null_dataset_rb.html
+        # @example result will always be empty, regardless if records exists
+        #   users.where(name: 'Alice').nullify
+        #
+        # @return [SQL::Relation]
+        #
+        # @api public
+        def nullify
+          new(dataset.__send__(__method__))
+        end
+
         private
 
         # Build a locking clause

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
 
       expect(connection).to receive(:extension).with(:pg_array, :pg_json, :pg_enum, :pg_array_ops)
       expect(connection).to receive(:extension).with(:freeze_datasets) unless RUBY_ENGINE == 'rbx'
+      expect(connection).to receive(:extension).with(:null_dataset)
 
       ROM::SQL::Gateway.new(connection, extensions: extensions)
     end

--- a/spec/unit/relation/nullify_spec.rb
+++ b/spec/unit/relation/nullify_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe ROM::Relation, '#unfiltered' do
+  subject(:relation) { relations[:tasks].select(:id, :title) }
+
+  include_context 'users and tasks'
+
+  with_adapters do
+    it 'nullifies a relation which has records' do
+      expect(relation.to_a).not_to be_empty
+      expect(relation.nullify.to_a).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
I noticed there wasn't a simple way to nullify a relation. This functionality is common in Sequel and Rails (`ActiveRecord::Relation#none`). Will make it easier to short circuit any DB interactions when necessary.