### PR TITLE
Wrap JSON primitives before passing them to Sequel (fix #327)

### DIFF
--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -73,12 +73,20 @@ RSpec.describe 'ROM::SQL::Postgres::Types' do
       expect(output.to_a).to eql(input)
     end
 
-    it 'accepts any other type of objects' do
-      input  = [nil, 1, 'sutin', :sutin, 1.0].sample
-      output = described_class[input]
+    it 'accepts any other json primitives' do
+      [nil, 1, 'sutin', 1.0].each do |input|
+        output = described_class[input]
 
-      expect(output).to be_instance_of(Sequel::Postgres::JSONOp)
-      expect(output.value).to eql(input)
+        expect(output).to be_a(Sequel::Postgres::JSONObject)
+        expect(output.__getobj__).to be(input)
+      end
+    end
+
+    it 'falls back to JSONOp for other objects' do
+      output = described_class[:sutin]
+
+      expect(output).to be_a(Sequel::Postgres::JSONOp)
+      expect(output.value).to be(:sutin)
     end
   end
 
@@ -99,12 +107,13 @@ RSpec.describe 'ROM::SQL::Postgres::Types' do
       expect(output.to_a).to eql(input)
     end
 
-    it 'accepts any other type of objects' do
-      input  = [nil, 1, 'sutin', :sutin, 1.0].sample
-      output = described_class[input]
+    it 'accepts any other json primitives' do
+      [nil, 1, 'sutin', 1.0].each do |input|
+        output = described_class[input]
 
-      expect(output).to be_instance_of(Sequel::Postgres::JSONBOp)
-      expect(output.value).to eql(input)
+        expect(output).to be_a(Sequel::Postgres::JSONBObject)
+        expect(output.__getobj__).to be(input)
+      end
     end
   end
 


### PR DESCRIPTION
This adds support for writing primitive values to JSON(B) columns. Sequel has recently added support for it. On the rom-sql's side we only need to change the wrapper.

Other values are interpreted as JSONOp as they did before. We could revise this behavior in the next major version, it was added for compatibility with Hanami < 1.0 but I'm not sure if we still need it.