### PR TITLE
Properly qualify relations when in Relation#union

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -807,7 +807,16 @@ module ROM
         #
         # @api public
         def union(relation, options = EMPTY_HASH, &block)
-          new(dataset.__send__(__method__, relation.dataset, options, &block))
+          # We use the original relation name here if both relations have the
+          # same name. This makes it so if the user at some point references
+          # the relation directly by name later on things won't break in
+          # confusing ways.
+          same_relation = name == relation.name
+          alias_name =  same_relation ? name : "#{name.to_sym}__#{relation.name.to_sym}"
+          opts = { alias: alias_name.to_sym, **options }
+
+          new_schema = schema.qualified(opts[:alias])
+          new_schema.(new(dataset.__send__(__method__, relation.dataset, opts, &block)))
         end
 
         # Checks whether a relation has at least one tuple

--- a/spec/unit/relation/union_spec.rb
+++ b/spec/unit/relation/union_spec.rb
@@ -3,17 +3,76 @@ RSpec.describe ROM::Relation, '#union' do
 
   include_context 'users and tasks'
 
+  before do
+    conf.relation(:tasks) do
+      schema(infer: true) do
+        associations do
+          has_many :task_tags
+        end
+      end
+    end
+
+    conf.relation(:task_tags) do
+      schema(infer: true) do
+        associations do
+          belongs_to :task
+        end
+      end
+    end
+  end
+
   with_adapters do
-    let(:relation1) { relation.where(id: 1).select(:id, :name) }
-    let(:relation2) { relation.where(id: 2).select(:id, :name) }
+    let(:tasks) { container.relations.tasks}
+    let(:task_tags) { container.relations.task_tags}
 
-    it 'unions two relations and returns a new relation' do
-      result = relation1.union(relation2)
+    context 'when the relations unioned have the same name' do
+      let(:relation1) { relation.where(id: 1).select(:id, :name) }
+      let(:relation2) { relation.where(id: 2).select(:id, :name) }
 
-      expect(result.to_a).to match_array([
-        { id: 1, name: 'Jane' },
-        { id: 2, name: 'Joe' }
-      ])
+      it 'unions two relations and returns a new relation' do
+        result = relation1.union(relation2)
+
+        expect(result.to_a).to match_array([
+          { id: 1, name: 'Jane' },
+          { id: 2, name: 'Joe' }
+        ])
+      end
+
+      it 'correctly handles Sequels aliasing' do
+        tags1 = tasks
+          .left_join(task_tags, task_tags[:task_id] => tasks[:id], tasks[:title] => "Jane's Task")
+
+        tags2 = tasks
+          .left_join(task_tags, task_tags[:task_id] => tasks[:id], tasks[:title] => "Joes's Task")
+
+        unioned = tags1.union(tags2)
+        result = unioned.select_append(unioned[:title].as(:task_title))
+
+        expect(result.to_a).to match_array([
+          {:id=>1, :task_title=>"Joe's task", :title=>"Joe's task", :user_id=>2},
+          {:id=>2, :task_title=>"Jane's task", :title=>"Jane's task", :user_id=>1},
+        ])
+      end
+
+      it 'qualifies the table original relation name' do
+        result = relation1.union(relation2)
+        expect_to_have_qualified_name(result, :users)
+      end
+    end
+
+    context 'when the relations unioned have different names' do
+      let(:relation1) { relation.where(id: 1).select(:id, :name) }
+      let(:relation2) { tasks }
+
+      it 'qualifies the table as the concatenated relation names' do
+        result = relation1.union(relation2)
+        expect_to_have_qualified_name(result, :users__tasks)
+      end
+    end
+
+    def expect_to_have_qualified_name(rel, name)
+      metas = rel.schema.map(&:meta)
+      expect(metas).to all(include(qualified: name))
     end
   end
 end


### PR DESCRIPTION
When Sequel performs a union of two datasets, it will alias the resulting union as `t1` by default. As a result, `select_append` anything that required a qualified column will not work after performing a union. 

To fix this, this PR ensures we qualify the schema when performing a union. If relation_a and relation_b are of the `Relation::Name`, then we use that name as the alias. If they are different, we default the alias to `#{relation_a.name}__#{relation_b.name}`. This is not _technically_ required, but IMO makes the relation more easily inspectable/debuggable, and is more resistant to cases when user's manually qualify columns.