### PR TITLE
Honor association views when wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   users.nullify.to_a # => will always be empty ([])
   ```
 
+### Fixed
+
+- Make `Relation#wrap` respect association views (@ianks)
 - Primitive JSON-compatible values such as Integer and String are automatically coerced to correct JSONB values and back if you're using a recent Sequel version (>= 5.2.0) (flash-gordon)
 
 [Compare v3.0.1...master](https://github.com/rom-rb/rom-sql/compare/v3.0.1...master)

--- a/lib/rom/sql/associations/core.rb
+++ b/lib/rom/sql/associations/core.rb
@@ -14,6 +14,14 @@ module ROM
 
           target.where(target_key => target_pks)
         end
+
+        # @api private
+        def wrapped
+          new_target = view ? target.send(view) : target
+          to_wrap = self.class.allocate
+          to_wrap.send(:initialize, definition, options.merge(target: new_target))
+          to_wrap.wrap
+        end
       end
     end
   end

--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -5,6 +5,8 @@ require 'rom/attribute'
 
 require 'rom/sql/type_extensions'
 require 'rom/sql/projection_dsl'
+require 'rom/sql/attribute_wrapping'
+require 'rom/sql/attribute_aliasing'
 
 module ROM
   module SQL
@@ -12,6 +14,9 @@ module ROM
     #
     # @api public
     class Attribute < ROM::Attribute
+      include AttributeWrapping
+      include AttributeAliasing
+
       OPERATORS = %i[>= <= > <].freeze
       NONSTANDARD_EQUALITY_VALUES = [true, false, nil].freeze
       META_KEYS = %i(index foreign_key target sql_expr qualified).freeze
@@ -25,21 +30,6 @@ module ROM
       def self.[](*args)
         fetch_or_store(args) { new(*args) }
       end
-
-      # Return a new attribute with an alias
-      #
-      # @example
-      #   users[:id].aliased(:user_id)
-      #
-      # @return [SQL::Attribute]
-      #
-      # @api public
-      def aliased(alias_name)
-        super.with(name: name || alias_name).meta(
-          sql_expr: sql_expr.as(alias_name)
-        )
-      end
-      alias_method :as, :aliased
 
       # Return a new attribute in its canonical form
       #

--- a/lib/rom/sql/attribute_aliasing.rb
+++ b/lib/rom/sql/attribute_aliasing.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ROM
+  module SQL
+    # @api private
+    module AttributeAliasing
+      # Return a new attribute with an alias
+      #
+      # @example
+      #   users[:id].aliased(:user_id)
+      #
+      # @return [SQL::Attribute]
+      #
+      # @api public
+      def aliased(alias_name)
+        new_name, new_alias_name = extract_alias_names(alias_name)
+
+        super(new_alias_name).with(name: new_name).meta(
+          sql_expr: alias_sql_expr(sql_expr, new_alias_name)
+        )
+      end
+      alias as aliased
+
+      private
+
+      # @api private
+      def alias_sql_expr(sql_expr, new_alias)
+        case sql_expr
+        when Sequel::SQL::AliasedExpression
+          Sequel::SQL::AliasedExpression.new(sql_expr.expression, new_alias, sql_expr.columns)
+        else
+          sql_expr.as(new_alias)
+        end
+      end
+
+      # @api private
+      def extract_alias_names(alias_name)
+        new_name, new_alias_name = nil
+
+        if wrapped? && aliased?
+          # If the attribute is wrapped *and* aliased, make sure that we name the
+          # attribute in a way that will map the the requested alias name.
+          # Without this, the attribute will silently ignore the requested alias
+          # name and default to the pre-existing name.
+          new_name = "#{meta[:wrapped]}_#{options[:alias]}".to_sym
+
+          # Essentially, this makes it so "wrapped" attributes aren't true
+          # aliases, in that we actually alias the wrapped attribute, we use
+          # the old alias.
+          new_alias_name = options[:alias]
+        else
+          new_name = name || alias_name
+          new_alias_name = alias_name
+        end
+
+        [new_name, new_alias_name]
+      end
+    end
+  end
+end

--- a/lib/rom/sql/attribute_wrapping.rb
+++ b/lib/rom/sql/attribute_wrapping.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ROM
+  module SQL
+    # @api private
+    module AttributeWrapping
+      # Return if the attribute type is from a wrapped relation
+      #
+      # Wrapped attributes are used when two schemas from different relations
+      # are merged together. This way we can identify them easily and handle
+      # correctly in places like auto-mapping.
+      #
+      # @api public
+      def wrapped?
+        !meta[:wrapped].nil?
+      end
+
+      # Return attribute type wrapped for the specified relation name
+      #
+      # @param [Symbol] name The name of the source relation (defaults to source.dataset)
+      #
+      # @return [Attribute]
+      #
+      # @api public
+      def wrapped(name = source.dataset)
+        meta(wrapped: name).prefixed(name)
+      end
+    end
+  end
+end

--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -1,4 +1,5 @@
 require 'rom/attribute'
+require 'rom/sql/attribute_wrapping'
 
 module ROM
   module SQL
@@ -6,6 +7,8 @@ module ROM
     #
     # @api public
     class Function < ROM::Attribute
+      include AttributeWrapping
+
       class << self
         # @api private
         def frame_limit(value)
@@ -36,6 +39,19 @@ module ROM
       WINDOW_FRAMES[:all] = WINDOW_FRAMES[rows: [:start, :end]]
       WINDOW_FRAMES[:rows] = WINDOW_FRAMES[rows: [:start, :current]]
       WINDOW_FRAMES[range: :current] = WINDOW_FRAMES[range: [:current, :current]]
+
+      # Return a new attribute with an alias
+      #
+      # @example
+      #   string::coalesce(users[:name], users[:id]).aliased(:display_name)
+      #
+      # @return [SQL::Function]
+      #
+      # @api public
+      def aliased(alias_name)
+        super.with(name: name || alias_name)
+      end
+      alias_method :as, :aliased
 
       # @api private
       def sql_literal(ds)

--- a/lib/rom/sql/mapper_compiler.rb
+++ b/lib/rom/sql/mapper_compiler.rb
@@ -7,10 +7,19 @@ module ROM
         name, _, meta_options = node
 
         if meta_options[:wrapped]
-          [name, from: meta_options[:alias]]
+          [extract_wrapped_name(node), from: meta_options[:alias]]
         else
           [name]
         end
+      end
+
+      private
+
+      def extract_wrapped_name(node)
+        _, _, meta_options = node
+        unwrapped_name = meta_options[:alias].to_s.dup
+        unwrapped_name.slice!("#{meta_options[:wrapped]}_")
+        unwrapped_name.to_sym
       end
     end
   end

--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -1011,6 +1011,21 @@ module ROM
           new(dataset.__send__(__method__))
         end
 
+        # Wrap other relations using association names
+        #
+        # @example
+        #   tasks.wrap(:owner)
+        #
+        # @param [Array<Symbol>] names A list with association identifiers
+        #
+        # @return [Wrap]
+        #
+        # @api public
+        def wrap(*names)
+          others = names.map { |name| associations[name].wrapped }
+          wrap_around(*others)
+        end
+
         private
 
         # Build a locking clause

--- a/spec/unit/attribute_spec.rb
+++ b/spec/unit/attribute_spec.rb
@@ -94,6 +94,13 @@ RSpec.describe ROM::SQL::Attribute, :postgres do
     end
   end
 
+  describe '#aliased' do
+    it 'can alias a previously aliased attribute' do
+      expect(users[:id].as(:uid).as(:uuid).sql_literal(ds)).
+        to eql(%("users"."id" AS "uuid"))
+    end
+  end
+
   describe 'extensions' do
     before do
       ROM::SQL::TypeExtensions.instance_variable_get(:@types)['sqlite'].delete('custom')


### PR DESCRIPTION
Previously, when wrapping a relation, the view for the association would not be honored. This would make the output of `.wrap` different from combine, and cause unexpected behavior.

This PR addresses that by first applying the view to the association target if there is one. 

Also, since `.wrap` with prefix attributes, any previously aliased attributes would fail loudly since `Sequel::SQL::AliasedExpression` does not respond to `.as`. To fix this, we now will handle alias `Sequel::SQL::AliasedExpression` by constructing a new instance with the new alias name.