### PR TITLE
Don't remove order in subqueries

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -995,7 +995,7 @@ module ROM
         # @return [SQL::Attribute]
         def query
           attr = schema.to_a[0]
-          subquery = schema.project(attr).(self).dataset.unordered
+          subquery = schema.project(attr).(self).dataset
           SQL::Attribute[attr.type].meta(sql_expr: subquery)
         end
 

--- a/spec/unit/relation/project_spec.rb
+++ b/spec/unit/relation/project_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ROM::Relation, '#project' do
                         project { integer::count(id) }.
                         where(tasks[:user_id] => users[:id]).
                         where(tasks[:title].ilike('joe%')).
+                        order(nil).
                         query
 
         results = relation.project { [id, tasks_count.as(:tasks_count)] }.to_a

--- a/spec/unit/relation/where_spec.rb
+++ b/spec/unit/relation/where_spec.rb
@@ -98,6 +98,21 @@ RSpec.describe ROM::Relation, '#where' do
                  ).to_a
         expect(rows.size).to eql(2)
       end
+
+      it 'really works with subqueries' do
+        conn[:users].insert name: 'Jane'
+
+        tasks = self.tasks
+        users = self.users
+        rows = relation.
+                 where(
+                   tasks[:user_id].is(
+                     users.select(:id).order { name.desc }.limit(1).query
+                   )
+                 ).to_a
+
+        expect(rows).to match([{ id: an_instance_of(Integer), title: "Joe's task" }])
+      end
     end
 
     context 'with :read types' do


### PR DESCRIPTION
Although removing ORDER BY part from a subquery (as rom-sql currently does) may seem innocent, it really isn't and it leads to bugs.

Consider the following query:

```sql
CREATE TABLE users(id INT, name TEXT);
CREATE TABLE tasks(id INT, user_id INT, title TEXT);

INSERT INTO users(id, name) VALUES 
(1, 'Jane'), 
(2, 'Alice'), 
(3, 'John');

INSERT INTO tasks(user_id, title) VALUES 
(1, 'Jane''s task'), 
(2, 'Alice''s task'), 
(3, 'John''s task');

SELECT user_id, title
FROM tasks
WHERE user_id IN (SELECT id FROM users ORDER BY name LIMIT 1)
--  user_id |    title
-- ---------+--------------
--        2 | Alice's task


SELECT user_id, title
FROM tasks
WHERE user_id IN (SELECT id FROM users LIMIT 1);
--  user_id |    title
-- ---------+-------------
--        1 | Jane's task
```

Here, we list all the task of the user *whose name is alphabetically first*.

If we remove the order, however, this query becomes non-deterministic and tasks of a *random user* are returned. Typically, it's the user with the smallest id, but the database is free to chose any record.

So, let's not be overly smart and not do `unordered` for the subqueries. Let's be explicit. Sometimes it may mean that a user have to call `reorder(nil)` explicitly themselves (like I did in a spec which broke after my change), but that's good. Explicit is better than implicit. Especially if there are bugs hiding behind the implicitness.

Note that in order to be able to run tests I had to apply the patch below. This is a known issue: https://github.com/rom-rb/rom-sql/issues/341.

```diff
diff --git a/rom-sql.gemspec b/rom-sql.gemspec
index 041241b..ff7cf62 100644
--- a/rom-sql.gemspec
+++ b/rom-sql.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-types', '~> 1.0'
   spec.add_runtime_dependency 'dry-core', '~> 0.4'
   spec.add_runtime_dependency 'rom-core', '~> 5.0', '>= 5.0.1'
+  spec.add_runtime_dependency 'rom', '~> 5.0', '>= 5.0.1'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
```