### PR TITLE
Support new dry-types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ if ENV['USE_ROM_MASTER'] == 'true'
   gem 'rom-core', github: 'rom-rb/rom'
 end
 
+gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
+
 gemspec
 
 group :test do

--- a/lib/rom/sql/extensions/postgres/types/array.rb
+++ b/lib/rom/sql/extensions/postgres/types/array.rb
@@ -151,8 +151,7 @@ module ROM
           private
 
           def cast(type, value)
-            db_type = type.optional? ? type.right.meta[:type] : type.meta[:type]
-            Sequel.cast(value, db_type)
+            Sequel.cast(value, type.meta[:type])
           end
         end
       end

--- a/lib/rom/sql/type_extensions.rb
+++ b/lib/rom/sql/type_extensions.rb
@@ -12,9 +12,7 @@ module ROM
         # @return [Hash]
         #
         # @api public
-        def [](wrapped)
-          type = wrapped.default? ? wrapped.type : wrapped
-          type = type.optional? ? type.right : type
+        def [](type)
           @types[type.meta[:database]][type.meta[:db_type]] || EMPTY_HASH
         end
 

--- a/spec/extensions/postgres/types_spec.rb
+++ b/spec/extensions/postgres/types_spec.rb
@@ -82,6 +82,13 @@ RSpec.describe 'ROM::SQL::Postgres::Types' do
       end
     end
 
+    it 'maps JSONNull to nil' do
+      # this is a special value to differentiate optional JSON(B) columns with
+      # SQL null from JSON(B) with JSON null
+      expect(described_class[ROM::SQL::Types::PG::JSONNull]).to be_a(Sequel::Postgres::JSONNull)
+      expect(described_class[ROM::SQL::Types::PG::JSONNull].__getobj__).to be_nil
+    end
+
     it 'falls back to JSONOp for other objects' do
       output = described_class[:sutin]
 
@@ -114,6 +121,13 @@ RSpec.describe 'ROM::SQL::Postgres::Types' do
         expect(output).to be_a(Sequel::Postgres::JSONBObject)
         expect(output.__getobj__).to be(input)
       end
+    end
+
+    it 'maps JSONNull to nil' do
+      # this is a special value to differentiate optional JSON(B) columns with
+      # SQL null from JSON(B) with JSON null
+      expect(described_class[ROM::SQL::Types::PG::JSONNull]).to be_a(Sequel::Postgres::JSONBNull)
+      expect(described_class[ROM::SQL::Types::PG::JSONNull].__getobj__).to be_nil
     end
   end
 

--- a/spec/integration/auto_migrations/postgres/column_types_spec.rb
+++ b/spec/integration/auto_migrations/postgres/column_types_spec.rb
@@ -62,41 +62,40 @@ RSpec.describe ROM::SQL::Gateway, :postgres, :helpers do
     it 'has support for PG data types' do
       gateway.auto_migrate!(conf, inline: true)
 
-      expect(migrated_schema.to_h).
-        to eql(
-             attributes(
-               id: ROM::SQL::Types::Integer.meta(primary_key: true),
-               string: ROM::SQL::Types::String,
-               int: ROM::SQL::Types::Integer,
-               time: ROM::SQL::Types::Time,
-               date: ROM::SQL::Types::Date,
-               decimal: ROM::SQL::Types::Decimal,
-               string_nullable: ROM::SQL::Types::String.optional,
-               jsonb: ROM::SQL::Types::PG::JSONB,
-               json: ROM::SQL::Types::PG::JSON,
-               tags: ROM::SQL::Types::PG::Array('text'),
-               money: ROM::SQL::Types::PG::Money,
-               uuid: ROM::SQL::Types::PG::UUID,
-               bytea: ROM::SQL::Types::PG::Bytea,
-               hstore: ROM::SQL::Types::PG::HStore,
-               inet: ROM::SQL::Types::PG::IPAddress,
-               xml: ROM::SQL::Types::PG::XML,
-               point: ROM::SQL::Types::PG::Point,
-               line: ROM::SQL::Types::PG::Line,
-               circle: ROM::SQL::Types::PG::Circle,
-               box: ROM::SQL::Types::PG::Box,
-               lseg: ROM::SQL::Types::PG::LineSegment,
-               polygon: ROM::SQL::Types::PG::Polygon,
-               path: ROM::SQL::Types::PG::Path,
-               int4range: ROM::SQL::Types::PG::Int4Range,
-               int8range: ROM::SQL::Types::PG::Int8Range,
-               numrange: ROM::SQL::Types::PG::NumRange,
-               tsrange: ROM::SQL::Types::PG::TsRange,
-               tstzrange: ROM::SQL::Types::PG::TsTzRange,
-               daterange: ROM::SQL::Types::PG::DateRange,
-               ltree_path: ROM::SQL::Types::PG::LTree
-             )
-           )
+      expect(migrated_schema.to_h).to eql(
+        attributes(
+          id: ROM::SQL::Types::Integer.meta(primary_key: true),
+          string: ROM::SQL::Types::String,
+          int: ROM::SQL::Types::Integer,
+          time: ROM::SQL::Types::Time,
+          date: ROM::SQL::Types::Date,
+          decimal: ROM::SQL::Types::Decimal,
+          string_nullable: ROM::SQL::Types::String.optional,
+          jsonb: ROM::SQL::Types::PG::JSONB,
+          json: ROM::SQL::Types::PG::JSON,
+          tags: ROM::SQL::Types::PG::Array('text'),
+          money: ROM::SQL::Types::PG::Money,
+          uuid: ROM::SQL::Types::PG::UUID,
+          bytea: ROM::SQL::Types::PG::Bytea,
+          hstore: ROM::SQL::Types::PG::HStore,
+          inet: ROM::SQL::Types::PG::IPAddress,
+          xml: ROM::SQL::Types::PG::XML,
+          point: ROM::SQL::Types::PG::Point,
+          line: ROM::SQL::Types::PG::Line,
+          circle: ROM::SQL::Types::PG::Circle,
+          box: ROM::SQL::Types::PG::Box,
+          lseg: ROM::SQL::Types::PG::LineSegment,
+          polygon: ROM::SQL::Types::PG::Polygon,
+          path: ROM::SQL::Types::PG::Path,
+          int4range: ROM::SQL::Types::PG::Int4Range,
+          int8range: ROM::SQL::Types::PG::Int8Range,
+          numrange: ROM::SQL::Types::PG::NumRange,
+          tsrange: ROM::SQL::Types::PG::TsRange,
+          tstzrange: ROM::SQL::Types::PG::TsTzRange,
+          daterange: ROM::SQL::Types::PG::DateRange,
+          ltree_path: ROM::SQL::Types::PG::LTree
+        )
+      )
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -38,9 +38,7 @@ module Helpers
         attr = ROM::SQL::Attribute.new(type, name: key)
       end
 
-      meta = { source: source }
-
-      acc[key] = attr.meta(meta)
+      acc[key] = attr.meta(source: source)
     end
   end
 end


### PR DESCRIPTION
A few tweaks to make it work. The trick is not to confuse SQL `null` with JSON `null`. If you want to write JSON `null` to an optional JSON(b) column you'll have to use `ROM::SQL::Types::PG::JSONNull`. Other cases will work just fine.