### PR TITLE
Add bin/run-specs helper for easier testing in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In order to test the changes, execute:
 
 ```bash
 docker-compose build gem
-docker-compose run --rm gem 'rspec'
+bin/run-specs
 ```
 
 ### Stopping the dependencies

--- a/bin/run-specs
+++ b/bin/run-specs
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec docker-compose run --rm gem "bundle exec rspec $*"


### PR DESCRIPTION
running the `docker-compose` command is tedious for testing. This PR adds a `bin/run-specs` helper with the same interface as rspec, but runs specs in the docker containers.