### PR TITLE
Remove ORDER to make COUNT faster

### DIFF
--- a/lib/rom/sql/plugin/pagination.rb
+++ b/lib/rom/sql/plugin/pagination.rb
@@ -62,7 +62,7 @@ module ROM
           #
           # @api public
           def total
-            dataset.unlimited.count
+            dataset.unlimited.order(nil).count
           end
 
           # Return total number of pages


### PR DESCRIPTION
Lifted from `graphql-ruby`: https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/pagination/sequel_dataset_connection.rb#L19