### PR TITLE
User documentation link returns a 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Links
 
-* [User documentation](http://rom-rb.org/learn/rom-sql)
+* [User documentation](https://rom-rb.org/learn/sql)
 * [API documentation](http://rubydoc.info/gems/rom-sql)
 
 ## Supported Ruby versions


### PR DESCRIPTION
The `rom-sql` path does not exists anymore, this commit updates the link to rom-rb.org to `sql`