### PR TITLE
Fix malformed sql when sql methods given aliased attribute instances

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -477,7 +477,7 @@ module ROM
           if block
             new(dataset.order(*args, *schema.canonical.order(&block)))
           else
-            new(dataset.__send__(__method__, *args, &block))
+            new(dataset.__send__(__method__, *canonicalize_args(args), &block))
           end
         end
 
@@ -1100,6 +1100,26 @@ module ROM
             end
           else
             raise ArgumentError, "+other+ must be either a symbol or a relation, #{other.class} given"
+          end
+        end
+
+        # Coerces {ROM::SQL::Attribute} arguments into their
+        # canonical form
+        #
+        # Used by relation functions that accept attributes but don't
+        # want aliased attributes to generate invalid sql
+        #
+        # @api private
+        def canonicalize_args(args)
+          if args.is_a?(Array)
+            args.map do |arg|
+              next arg unless arg.is_a?(ROM::SQL::Attribute)
+              arg.canonical
+            end
+          elsif args.is_a?(ROM::SQL::Attribute)
+            arg.canonical
+          else
+            arg
           end
         end
       end

--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -1080,7 +1080,7 @@ module ROM
             elsif block
               __join__(type, other, JoinDSL.new(schema).(&block), opts)
             else
-              new(dataset.__send__(type, other.to_sym, join_cond, opts, &block))
+              new(dataset.__send__(type, other.to_sym, canonicalize_args(join_cond), opts, &block))
             end
           elsif other.is_a?(Sequel::SQL::AliasedExpression)
             new(dataset.__send__(type, other, join_cond, opts, &block))
@@ -1112,14 +1112,20 @@ module ROM
         # @api private
         def canonicalize_args(args)
           if args.is_a?(Array)
-            args.map do |arg|
+            args.map {|arg|
               next arg unless arg.is_a?(ROM::SQL::Attribute)
               arg.canonical
-            end
+            }
+          elsif args.is_a?(Hash)
+            args.each_with_object({}) {|(k, v), h|
+              key = k.is_a?(ROM::SQL::Attribute) ? k.canonical : k
+              value = v.is_a?(ROM::SQL::Attribute) ? v.canonical : v
+              h[key] = value
+            }
           elsif args.is_a?(ROM::SQL::Attribute)
-            arg.canonical
+            args.canonical
           else
-            arg
+            args
           end
         end
       end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -141,6 +141,15 @@ module ROM
         new(EMPTY_ARRAY)
       end
 
+      # Return the canonical schema which is carried in all schema instances
+      #
+      # @return [Schema]
+      #
+      # @api public
+      def canonical
+        new(super.map(&:canonical))
+      end
+
       # Finalize all attributes by qualifying them and initializing primary key names
       #
       # @api private

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe ROM::Relation, '#inner_join' do
                                  ])
     end
 
+    it 'joins relations using inner join and aliased attributes' do
+      relation.insert id: 3, name: 'Jade'
+      user_id = users[:id].as(:key)
+      id = tasks[:user_id].as(:user_key)
+
+      result = relation
+               .inner_join(:tasks, user_id => id)
+               .select(:name, tasks[:title])
+
+      expect(result.schema.map(&:name)).to eql(%i[name title])
+
+      expect(result.to_a).to eql([
+                                   { name: 'Jane', title: "Jane's task" },
+                                   { name: 'Joe', title: "Joe's task" }
+                                 ])
+    end
+
     it 'allows specifying table_aliases' do
       relation.insert id: 3, name: 'Jade'
 

--- a/spec/unit/relation/order_spec.rb
+++ b/spec/unit/relation/order_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe ROM::Relation, '#order' do
         to eql([{ id: 3, name: 'Jade' }, { id: 1, name: 'Jane' }, { id: 2, name: 'Joe' }])
     end
 
+   it 'orders by provided attributes when aliased' do
+      attribs = [relation.schema[:name].aliased(:user_name), :id]
+      ordered = relation.order(*attribs)
+
+      expect(ordered.to_a).
+        to eql([{ id: 3, name: 'Jade' }, { id: 1, name: 'Jane' }, { id: 2, name: 'Joe' }])
+    end
+
     it 'orders by provided attribute using a block' do
       ordered = relation.
                   qualified.
@@ -24,6 +32,17 @@ RSpec.describe ROM::Relation, '#order' do
 
       expect(ordered.to_a).
         to eql([{ id: 2, name: 'Joe' }, { id: 1, name: 'Jane' }, { id: 3, name: 'Jade' }])
+    end
+
+    it 'orders by provided attribute when aliased using a block' do
+      ordered = relation.
+                  qualified.
+                  rename(name: :user_name).
+                  select(:id, :name).
+                  order { name.qualified.desc }
+
+      expect(ordered.to_a).
+        to eql([{ id: 2, user_name: 'Joe' }, { id: 1, user_name: 'Jane' }, { id: 3, user_name: 'Jade' }])
     end
 
     it 'orders by provided attribute from another relation' do


### PR DESCRIPTION
Fixes rom-rb/rom-sql#370

The main issue came from `Sequel::AliasedExpressions` being set as the attributes `:sql_expr` on every aliased attribute during schema finalization. It was a consequence of calling `:qualified` on all of the attributes.

As a consequence, the fix was to force "canonical" attributes for the schemas canonical instance. This allowed much of the `schema.canonical` calls littered throughout the sql reader methods to just automatically work.