### PR TITLE
relation#join block dsl should use dataset name not alias

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -1094,7 +1094,7 @@ module ROM
                 join_opts = EMPTY_HASH
               end
 
-              new(dataset.__send__(type, other.name.to_sym, join_cond, join_opts))
+              new(dataset.__send__(type, other.name.dataset.to_sym, join_cond, join_opts))
             else
               associations[other.name.key].join(type, self, other)
             end

--- a/spec/unit/relation/join_dsl_spec.rb
+++ b/spec/unit/relation/join_dsl_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe ROM::Relation, '#join_dsl', relations: false do
       end
     end
 
+    context 'using relation object with aliased dataset as the join relation' do
+      include_context 'valid joined relation' do
+        let(:users_arg) { users.with(name: ROM::Relation::Name.new(:my_users, :users)) }
+        let(:tasks_arg) { tasks }
+      end
+    end
+
     it 'can join using alias' do
       authors = users.as(:authors).qualified(:authors)
 


### PR DESCRIPTION
Fixes rom-rb/rom-sql#369

When `relation#join` is given a relation with an aliased dataset and a block it should use the relations dataset name instead of the relations name.