### PR TITLE
Add qualifed projections to schemas & update `dataset#select` calls

### DIFF
--- a/lib/rom/sql/attribute.rb
+++ b/lib/rom/sql/attribute.rb
@@ -67,6 +67,21 @@ module ROM
         end
       end
 
+      # Return a new attribute that is aliased and marked as qualified
+      #
+      # Intended to be used when passing attributes to `dataset#select`
+      #
+      # @return [SQL::Attribute]
+      #
+      # @api public
+      def qualified_projection(table_alias = nil)
+        if aliased?
+          qualified(table_alias).aliased(self.alias)
+        else
+          qualified(table_alias)
+        end
+      end
+
       # Return a new attribute marked as joined
       #
       # Whenever you join two schemas, the right schema's attribute
@@ -285,11 +300,11 @@ module ROM
       # @api private
       def to_sql_name
         @_to_sql_name ||=
-          if qualified? && aliased?
+          if qualified? && aliased_projection?
             Sequel.qualify(table_name, name).as(self.alias)
           elsif qualified?
             Sequel.qualify(table_name, name)
-          elsif aliased?
+          elsif aliased_projection?
             Sequel.as(name, self.alias)
           else
             Sequel[name]

--- a/lib/rom/sql/attribute_aliasing.rb
+++ b/lib/rom/sql/attribute_aliasing.rb
@@ -21,6 +21,34 @@ module ROM
       end
       alias as aliased
 
+
+      # Return true if this attribute is an aliased projection
+      #
+      # @example
+      #   class Tasks < ROM::Relation[:memory]
+      #     schema do
+      #       attribute :user_id, Types::Integer, alias: :id
+      #       attribute :name, Types::String
+      #     end
+      #   end
+      #
+      #   Users.schema[:user_id].aliased?
+      #   # => true
+      #   Users.schema[:user_id].aliased_projection?
+      #   # => false
+      #
+      #   Users.schema[:user_id].qualified_projection.aliased?
+      #   # => true
+      #   Users.schema[:user_id].qualified_projection.aliased_projection?
+      #   # => true
+      #
+      # @return [TrueClass,FalseClass]
+      #
+      # @api private
+      def aliased_projection?
+        self.meta[:sql_expr].is_a?(Sequel::SQL::AliasedExpression)
+      end
+
       private
 
       # @api private

--- a/lib/rom/sql/extensions/postgres/commands.rb
+++ b/lib/rom/sql/extensions/postgres/commands.rb
@@ -17,7 +17,7 @@ module ROM
           #
           # @api private
           def returning_dataset
-            relation.dataset.returning(*relation.qualified_columns)
+            relation.dataset.returning(*relation.schema.qualified_projection)
           end
         end
 

--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -78,6 +78,15 @@ module ROM
         )
       end
 
+      # @see Attribute#qualified_projection
+      #
+      # @api private
+      def qualified_projection(table_alias = nil)
+        meta(
+          func: ::Sequel::SQL::Function.new(func.name, *func.args.map { |arg| arg.respond_to?(:qualified_projection) ? arg.qualified_projection(table_alias) : arg })
+        )
+      end
+
       # @see Attribute#qualified?
       #
       # @api private

--- a/lib/rom/sql/relation.rb
+++ b/lib/rom/sql/relation.rb
@@ -37,7 +37,7 @@ module ROM
           table = opts[:from].first
 
           if db.table_exists?(table)
-            select(*schema.map(&:qualified)).order(*schema.project(*schema.primary_key_names).qualified)
+            select(*schema.qualified_projection).order(*schema.project(*schema.primary_key_names).qualified)
           else
             self
           end

--- a/lib/rom/sql/schema.rb
+++ b/lib/rom/sql/schema.rb
@@ -67,6 +67,18 @@ module ROM
         new(map { |attr| attr.qualified(table_alias) })
       end
 
+      # Return a new schema with attributes that are aliased
+      # and marked as qualified
+      #
+      # Intended to be used when passing attributes to `dataset#select`
+      #
+      # @return [Schema]
+      #
+      # @api public
+      def qualified_projection(table_alias = nil)
+        new(map { |attr| attr.qualified_projection(table_alias) })
+      end
+
       # Project a schema
       #
       # @see ROM::Schema#project
@@ -129,7 +141,7 @@ module ROM
       #
       # @api public
       def call(relation)
-        relation.new(relation.dataset.select(*self), schema: self)
+        relation.new(relation.dataset.select(*self.qualified_projection), schema: self)
       end
 
       # Return an empty schema

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe ROM::Relation, '#inner_join' do
                                  ])
     end
 
+    it 'joins relations using inner join and attributes with alias set' do
+      relation.insert id: 3, name: 'Jade'
+      user_id = users[:id].with(alias: :key)
+      id = tasks[:user_id].with(alias: :user_key)
+
+      result = relation
+               .inner_join(:tasks, user_id => id)
+               .select(:name, tasks[:title])
+
+      expect(result.schema.map(&:name)).to eql(%i[name title])
+
+      expect(result.to_a).to eql([
+                                   { name: 'Jane', title: "Jane's task" },
+                                   { name: 'Joe', title: "Joe's task" }
+                                 ])
+    end
+
     it 'allows specifying table_aliases' do
       relation.insert id: 3, name: 'Jade'
 

--- a/spec/unit/relation/order_spec.rb
+++ b/spec/unit/relation/order_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe ROM::Relation, '#order' do
         to eql([{ id: 3, name: 'Jade' }, { id: 1, name: 'Jane' }, { id: 2, name: 'Joe' }])
     end
 
+    it 'orders by provided attributes with alias set' do
+      attribs = [relation.schema[:name].with(alias: :user_name), :id]
+      ordered = relation.order(*attribs)
+
+      expect(ordered.to_a).
+        to eql([{ id: 3, name: 'Jade' }, { id: 1, name: 'Jane' }, { id: 2, name: 'Joe' }])
+    end
+
     it 'orders by provided attribute using a block' do
       ordered = relation.
                   qualified.
@@ -24,6 +32,17 @@ RSpec.describe ROM::Relation, '#order' do
 
       expect(ordered.to_a).
         to eql([{ id: 2, name: 'Joe' }, { id: 1, name: 'Jane' }, { id: 3, name: 'Jade' }])
+    end
+
+    it 'orders by provided attribute when aliased using a block' do
+      ordered = relation.
+                  qualified.
+                  rename(name: :user_name).
+                  select(:id, :name).
+                  order { name.qualified.desc }
+
+      expect(ordered.to_a).
+        to eql([{ id: 2, user_name: 'Joe' }, { id: 1, user_name: 'Jane' }, { id: 3, user_name: 'Jade' }])
     end
 
     it 'orders by provided attribute from another relation' do


### PR DESCRIPTION
Fixes #370

Aliased attributes are context based and should default to the
defined dataset name when using them in most queries.

This fix prevents attributes from being aliased during finalization
and provides a way to tell attributes they will be used in a
context where their configured alias should override the default
attribute name.

(Note: after review and before the pull request is accepted, ping me and I'll squash these commits)