### PR TITLE
(doc) Adjust YARD annotations

### DIFF
--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -186,7 +186,7 @@ module ROM
       #   users.project { integer::count(:id).filter(name.is("Jack")).as(:jacks) }.order(nil)
       #   users.project { integer::count(:id).filter { name.is("John") }).as(:johns) }.order(nil)
       #
-      # @param [Hash,SQL::Attribute] Conditions
+      # @param condition [Hash,SQL::Attribute] Conditions
       # @yield [block] A block with restrictions
       #
       # @return [SQL::Function]
@@ -211,7 +211,7 @@ module ROM
       # @example
       #   households.project { fload::percentile_cont(0.5).within_group(income).as(:percentile) }
       #
-      # @param [Array] A list of expressions for sorting within a group
+      # @param args [Array] A list of expressions for sorting within a group
       # @yield [block] A block for getting the expressions using the Order DSL
       #
       # @return [SQL::Function]

--- a/lib/rom/sql/projection_dsl.rb
+++ b/lib/rom/sql/projection_dsl.rb
@@ -31,7 +31,7 @@ module ROM
       #   users.select { function(:count, :id).as(:total) }
       #
       # @param [Symbol] name SQL function
-      # @param [Symbol] attr
+      # @param [Symbol] attrs
       #
       # @return [Rom::SQL::Function]
       #

--- a/lib/rom/sql/type_extensions.rb
+++ b/lib/rom/sql/type_extensions.rb
@@ -9,7 +9,7 @@ module ROM
       class << self
         # Gets extensions for a type
         #
-        # @param [Dry::Types::Type] wrapped
+        # @param type [Dry::Types::Type] wrapped
         #
         # @return [Hash]
         #


### PR DESCRIPTION
This PR fixes a few YARD annotations to match current code.

This PR came when I had some warnings:

```
Building YARD (yri) index for rom-sql-3.2.0...
lib/rom/sql/function.rb:189: [UnknownParam] @param tag has unknown parameter name: Conditions. Did you mean `condition`?
lib/rom/sql/function.rb:214: [UnknownParam] @param tag has unknown parameter name: A
lib/rom/sql/projection_dsl.rb:34: [UnknownParam] @param tag has unknown parameter name: attr. Did you mean `attrs`?
lib/rom/sql/type_extensions.rb:12: [UnknownParam] @param tag has unknown parameter name: wrapped
```
