### PR TITLE
Update versions recommended in the docs

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -47,14 +47,14 @@ tracker](https://github.com/rom-rb/rom-rb.org/issues).
 
 ## Installing
 
-*Depends on:* `ruby v2.3.0` or greater
+*Depends on:* `ruby v2.4.0` or greater
 
 To install <mark>rom-sql</mark> add the following to your
 <mark>Gemfile</mark>.
 
 ```ruby
-gem 'rom',     '~> 4.0'
-gem 'rom-sql', '~> 2.0'
+gem 'rom',     '~> 5.2'
+gem 'rom-sql', '~> 3.2'
 ```
 
 Afterwards either load `rom-sql` through your bundler setup or manually in your custom


### PR DESCRIPTION
While reading the [rom-sql docs](https://rom-rb.org/learn/sql/3.2/), I 
found it interesting that the recommended versions were so old.

I've updated these to the latest version bands, and have also modified
the required ruby version to match the gem.