### PR TITLE
Ensure ManyToMany produces a unique schema for the left-side relation

### DIFF
--- a/lib/rom/sql/associations/many_to_many.rb
+++ b/lib/rom/sql/associations/many_to_many.rb
@@ -20,7 +20,7 @@ module ROM
               if target != self.target
                 target.schema.merge(join_schema)
               else
-                left.schema.project(*columns)
+                left.schema.uniq.project(*columns)
               end
             else
               target_schema


### PR DESCRIPTION
In rom master schemas now verify if their attributes are unique, this broke one of the specs here which revelead that ManyToMany would try to project left-side relation columns without taking into consideration that one of the columns may already exist in the schema. The fix was to simply ensure that the schema is unique before projecting.