### PR TITLE
Change `int` to `integer`

### DIFF
--- a/docsite/source/attributes.html.md
+++ b/docsite/source/attributes.html.md
@@ -74,7 +74,7 @@ class Users < ROM::Relation[:sql]
   schema(infer: true)
 
   def index
-    select(:id, :name, tasks[:id].func { int::count(id).as(:task_count) }).
+    select(:id, :name, tasks[:id].func { integer::count(id).as(:task_count) }).
       left_join(tasks).
       group(:id)
   end


### PR DESCRIPTION
`int` would throw:

```
undefined local variable or method `int' for #<ROM::SQL::ProjectionDSL:0x00007fd68d3d4850>
```

I looked at the source and saw that this should be `integer`.