### PR TITLE
Add `:pg_streaming` extension to support streaming tuples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,5 @@ group :test do
   gem 'jdbc-sqlite3', platforms: :jruby
   gem 'ruby-oci8', platforms: :ruby if ENV['ROM_USE_ORACLE']
   gem 'dotenv', require: false
+  gem 'sequel_pg', require: false, platforms: :ruby
 end

--- a/docsite/source/advanced-pg-support.html.md
+++ b/docsite/source/advanced-pg-support.html.md
@@ -24,6 +24,65 @@ users_with_emails = users.where { properties.has_key('email') }
 johns = users.where { properties.contain(name: 'John') }
 ```
 
+## Streaming
+
+If you are using PostgreSQL 9.2+ on the client, then you can enable streaming
+support. This allows you to stream returned tuples one at a time, instead of
+collecting the entire result set in memory (which is how PostgreSQL works by
+default). 
+
+Imagine you have a large relation that you would like to stream as a CSV:
+
+```ruby
+class Posts < ROM::Relation[:sql]
+  schema do
+    attribute :id, Types::Serial
+    attribute :title, Types::String
+    attribute :body, Types::String
+  end
+end
+
+class SomeHTTPController
+  def call(*)
+    # Stream the CSV to avoid keeping the entire dataset in memory
+    self.body = Enumerator.new do |yielder|
+      posts.steam_each { |p| yielder << CSV.generate_line([p.id, p.title, p.body]) }
+    end
+
+    self.status = 200
+
+    self.headers.merge!(
+      'Content-Type' => 'text/csv; charset=utf-8;',
+      'Content-Disposition' => %(attachment; filename="posts_export.csv"),
+      'Transfer-Encoding' => 'chunked'
+    )
+  end
+end
+```
+
+You could also efficiently stream to JSON using [Oj::StreamWriter](https://www.rubydoc.info/github/ohler55/oj/Oj/StreamWriter):
+
+```ruby
+class MassiveJSONSerializer
+  def call(relation)
+    output_file = Tempfile.new(['.json'])
+    json_writer = Oj::StreamWriter.new(output_file)
+    json_writer.push_array
+
+    relation.stream_each do |post|
+      json_writer.push_value(post.to_h)
+    end
+
+    json_writer.flush
+    output_file.rewind
+  end
+end
+
+output_file = MassiveJsonSerializer.new(posts).call
+
+output_file.read #=> "[{\"id\":1,\"title\":\"Foo bar\"},{\"id\":2,\"title\":\"My post name\"}]"
+```
+
 ## Learn more
 
 * [api::rom-sql::SQL](Attribute)

--- a/lib/rom/plugins/relation/sql/postgres/streaming.rb
+++ b/lib/rom/plugins/relation/sql/postgres/streaming.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module ROM
+  module Plugins
+    module Relation
+      module SQL
+        module Postgres
+          # PG-specific extensions which adds `Relation#stream` method
+          #
+          # @api public
+          module Streaming
+            extend Notifications::Listener
+
+            class StreamingNotSupportedError < StandardError; end
+
+            subscribe("configuration.gateway.connected") do |opts|
+              conn = opts[:connection]
+
+              next unless conn.database_type.to_sym == :postgres
+
+              next if defined?(JRUBY_VERSION)
+
+              begin
+                require "sequel_pg"
+              rescue LoadError
+                raise StreamingNotSupportedError, "add sequel_pg to Gemfile to use pg_streaming"
+              end
+
+              unless Sequel::Postgres.supports_streaming?
+                raise StreamingNotSupportedError, "postgres version does not support streaming"
+              end
+
+              conn.extension(:pg_streaming)
+            end
+
+            def self.included(klass)
+              super
+              ROM::Relation::Graph.include(Combined)
+            end
+
+            if defined?(JRUBY_VERSION)
+              # Allows you to stream returned rows one at a time, instead of
+              # collecting the entire result set in memory. Requires the `sequel_pg` gem
+              #
+              # @see https://github.com/jeremyevans/sequel_pg#streaming- sequel_pg docs
+              #
+              # @example
+              #   posts.steam_each { |post| puts CSV.generate_line(post) }
+              #
+              # @return [Relation]
+              #
+              # @api publicY_VERSION
+              def stream_each
+                raise StreamingNotSupportedError, "not supported on jruby"
+              end
+            else
+              # Allows you to stream returned rows one at a time, instead of
+              # collecting the entire result set in memory. Requires the `sequel_pg` gem
+              #
+              # @see https://github.com/jeremyevans/sequel_pg#streaming- sequel_pg docs
+              #
+              # @example
+              #   posts.steam_each { |post| puts CSV.generate_line(post) }
+              #
+              # @return [Relation]
+              #
+              # @api public
+              def stream_each
+                return to_enum unless block_given?
+
+                ds = dataset.stream
+
+                if auto_map?
+                  ds.each { |tuple| yield(mapper.([output_schema[tuple]]).first) }
+                else
+                  ds.each { |tuple| yield(output_schema[tuple]) }
+                end
+              end
+
+              module Combined
+                def stream_each
+                  raise StreamingNotSupportedError, "not supported on combined relations"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ROM.plugins do
+  adapter :sql do
+    register :pg_streaming, ROM::Plugins::Relation::SQL::Postgres::Streaming, type: :relation
+  end
+end

--- a/lib/rom/sql/extensions/postgres.rb
+++ b/lib/rom/sql/extensions/postgres.rb
@@ -6,3 +6,4 @@ require 'rom/sql/extensions/postgres/type_builder'
 require 'rom/sql/extensions/postgres/type_serializer'
 require 'rom/plugins/relation/sql/postgres/explain'
 require 'rom/plugins/relation/sql/postgres/full_text_search'
+require "rom/plugins/relation/sql/postgres/streaming"

--- a/lib/rom/sql/gateway.rb
+++ b/lib/rom/sql/gateway.rb
@@ -81,6 +81,7 @@ module ROM
       def initialize(uri, options = EMPTY_HASH)
         @connection = connect(uri, options)
         load_extensions(Array(options[:extensions]))
+        Notifications.trigger("configuration.gateway.connected", connection: @connection)
 
         @options = options
 
@@ -247,4 +248,6 @@ module ROM
       end
     end
   end
+
+  Configuration.register_event("configuration.gateway.connected")
 end

--- a/spec/integration/plugins/pg_streaming_spec.rb
+++ b/spec/integration/plugins/pg_streaming_spec.rb
@@ -1,48 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe "Plugins / :pg_streaming", seeds: true do
-  with_adapters do
-    if metadata[:postgres]
-      include_context "users and tasks"
+  with_adapters(:postgres) do
+    include_context "users and tasks"
 
-      before do
-        skip 'it is not supported by jruby' if jruby?
-        conf.plugin(:sql, relations: :pg_streaming)
-      end
+    before do
+      skip "it is not supported by jruby" if jruby?
+      conf.plugin(:sql, relations: :pg_streaming)
+    end
 
-      it "can stream relations" do
-        result = []
+    it "can stream relations" do
+      result = []
 
-        tasks.stream_each { |task| result << task }
+      tasks.stream_each { |task| result << task }
 
-        expect(result).to eql(tasks.dataset.to_a)
-      end
+      expect(result).to eql(tasks.dataset.to_a)
+    end
 
-      it "can stream relations when auto_struct: true is set" do
-        result = []
+    it "can stream relations when auto_struct: true is set" do
+      result = []
 
-        tasks.with(auto_struct: true).stream_each { |task| result << task }
+      tasks.with(auto_struct: true).stream_each { |task| result << task }
 
-        aggregate_failures do
-          tasks.dataset.to_a.each_with_index do |task_attrs, i|
-            expect(result[i]).to have_attributes(task_attrs)
-          end
+      aggregate_failures do
+        tasks.dataset.to_a.each_with_index do |task_attrs, i|
+          expect(result[i]).to have_attributes(task_attrs)
         end
       end
+    end
 
-      it "can be lazily streamed" do
-        result = tasks.stream_each.lazy.take(1)
+    it "can be lazily streamed" do
+      result = tasks.stream_each.lazy.take(1)
 
-        expect(result.to_a).to contain_exactly(tasks.first)
-      end
+      expect(result.to_a).to contain_exactly(tasks.first)
+    end
 
-      it "is does not work on combined relations" do
-        combined_relation = users.combine(tasks)
+    it "is does not work on combined relations" do
+      combined_relation = users.combine(tasks)
 
-        expect { combined_relation.stream_each }.to raise_error(
-          ROM::Plugins::Relation::SQL::Postgres::Streaming::StreamingNotSupportedError
-        )
-      end
+      expect { combined_relation.stream_each }.to raise_error(
+        ROM::Plugins::Relation::SQL::Postgres::Streaming::StreamingNotSupportedError
+      )
     end
   end
 end

--- a/spec/integration/plugins/pg_streaming_spec.rb
+++ b/spec/integration/plugins/pg_streaming_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe "Plugins / :pg_streaming", seeds: true do
+  with_adapters do
+    if metadata[:postgres]
+      include_context "users and tasks"
+
+      before do
+        skip 'it is not supported by jruby' if jruby?
+        conf.plugin(:sql, relations: :pg_streaming)
+      end
+
+      it "can stream relations" do
+        result = []
+
+        tasks.stream_each { |task| result << task }
+
+        expect(result).to eql(tasks.dataset.to_a)
+      end
+
+      it "can stream relations when auto_struct: true is set" do
+        result = []
+
+        tasks.with(auto_struct: true).stream_each { |task| result << task }
+
+        aggregate_failures do
+          tasks.dataset.to_a.each_with_index do |task_attrs, i|
+            expect(result[i]).to have_attributes(task_attrs)
+          end
+        end
+      end
+
+      it "can be lazily streamed" do
+        result = tasks.stream_each.lazy.take(1)
+
+        expect(result.to_a).to contain_exactly(tasks.first)
+      end
+
+      it "is does not work on combined relations" do
+        combined_relation = users.combine(tasks)
+
+        expect { combined_relation.stream_each }.to raise_error(
+          ROM::Plugins::Relation::SQL::Postgres::Streaming::StreamingNotSupportedError
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe ROM::SQL::Gateway, :postgres do
       extensions = [:pg_array, :pg_array_ops]
       connection = Sequel.connect uri
 
+      allow(connection).to receive(:extension).with(:pg_streaming)
       expect(connection).to receive(:extension).with(:pg_array, :pg_json, :pg_enum, :pg_array_ops)
       expect(connection).to receive(:extension).with(:freeze_datasets) unless RUBY_ENGINE == 'rbx'
       expect(connection).to receive(:extension).with(:null_dataset)


### PR DESCRIPTION
This PR wraps the `sequel_pg`'s streaming functionality up in a neat little bow. We have a maintain a patch that adds this and have been using it in prod for quite awhile. Figured it was time to release it to the world!