### PR TITLE
Add Relation#unordered

### DIFF
--- a/lib/rom/sql/function.rb
+++ b/lib/rom/sql/function.rb
@@ -192,8 +192,8 @@ module ROM
       # Filter aggregate using the specified conditions
       #
       # @example
-      #   users.project { integer::count(:id).filter(name.is("Jack")).as(:jacks) }.order(nil)
-      #   users.project { integer::count(:id).filter { name.is("John") }).as(:johns) }.order(nil)
+      #   users.project { integer::count(:id).filter(name.is("Jack")).as(:jacks) }.unordered
+      #   users.project { integer::count(:id).filter { name.is("John") }).as(:johns) }.ordered
       #
       # @param condition [Hash,SQL::Attribute] Conditions
       # @yield [block] A block with restrictions

--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -481,6 +481,18 @@ module ROM
           end
         end
 
+        # Removes ordering for the relation
+        #
+        # @example
+        #   users.unordered
+        #
+        # @return [Relation]
+        #
+        # @api public
+        def unordered
+          new(dataset.unordered)
+        end
+
         # Reverse the order of the relation
         #
         # @example

--- a/spec/unit/relation/group_spec.rb
+++ b/spec/unit/relation/group_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ROM::Relation, '#group' do
       grouped = notes
                   .select { [integer::count(id).as(:count), time::date_trunc('day', created_at).as(:date)] }
                   .group { date_trunc('day', created_at) }
-                  .order(nil)
+                  .unordered
 
       expect(grouped.to_a).to eql([ count: 1, date: Date.today.to_time ])
     end

--- a/spec/unit/relation/project_spec.rb
+++ b/spec/unit/relation/project_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ROM::Relation, '#project' do
                         project { integer::count(id).as(:id) }.
                         where(tasks[:user_id] => users[:id]).
                         where(tasks[:title].ilike('joe%')).
-                        order(nil).
+                        unordered.
                         query
 
         results = relation.project { [id, tasks_count.as(:tasks_count)] }.to_a


### PR DESCRIPTION
Uses Sequel's built-in unordered to remove the order clause from queries.

Today I was trying to do this query:

```ruby
select { [integer::count(id).as(:count), user_id, project_id] }.group_and_count(:project_id, :user_id)
```

But I was told I could not do that:

```
[30] pry(#<TicketsRelation>)> select { [integer::count(id).as(:count), user_id, project_id] }.group_and_count(:project_id, :user_id).to_a
  ROM[postgres] (0.8ms)  SELECT "project_id", "user_id", count(*) AS "count" FROM "tickets" GROUP BY "project_id", "user_id" ORDER BY "tickets"."id"
Sequel::DatabaseError: PG::GroupingError: ERROR:  column "tickets.id" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: ...ickets" GROUP BY "project_id", "user_id" ORDER BY "tickets"....
```

This is because datasets are ordered by `id` by default.

After some googling, I found Sequel provides `unordered`, but `rom-sql` did not. Seemingly, the way to do it in rom-sql is `order(nil)`:

```ruby
select { [integer::count(id).as(:count), user_id, project_id] }.order(nil).group_and_count(:project_id, :user_id)
```

I think `unordered` is a clearer API for just a few lines of code, and it'll match what Sequel provides.

```ruby
select { [integer::count(id).as(:count), user_id, project_id] }.unordered.group_and_count(:project_id, :user_id)
```