### PR TITLE
Add migration_options to be able to use the default rake migration tasks with custom opts.

### DIFF
--- a/docsite/source/migrations.html.md
+++ b/docsite/source/migrations.html.md
@@ -33,6 +33,22 @@ The following tasks are available:
 * `rake db:clean` - removes all tables
 * `rake db:reset` - removes all tables and re-runs migrations
 
+With the help of the `migration_options` you can set certain customizations:
+
+# your rakefile
+
+require 'rom/sql/rake_task'
+
+namespace :db do
+  task :setup do
+    # ROM::SQL::RakeSupport.env = ROM.container(...)
+    ROM::SQL::RakeSupport.migration_options = {
+      table: :_custom_schema_table, # defaults to :schema_migrations,
+      column :_custom_schema_column, # defaults to :filename
+    }
+  end
+end
+
 ### File-based migrations
 
 Migrations created with a command such as `rake db:create_migration[create_users]` will be placed at under the `db/migrate` folder at the root of your project.

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -10,7 +10,7 @@ module ROM
 
       class << self
         def run_migrations(options = {})
-          gateway.run_migrations(options)
+          gateway.run_migrations(migration_options.merge(options))
         end
 
         def create_migration(*args)
@@ -22,7 +22,7 @@ module ROM
         # or something similar.
         #
         # @api public
-        attr_accessor :env
+        attr_accessor :env, :migration_options
 
         private
 
@@ -40,6 +40,7 @@ module ROM
       end
 
       @env = nil
+      @migration_options = {}
     end
   end
 end


### PR DESCRIPTION
Hey,
I want to use the default rake migration tasks, but need to customize the table opt. This PR would fix my need.

thanks and best regards 