### PR TITLE
Add migration_options to be able to use the default rake migration tasks with custom opts.

### DIFF
--- a/docsite/source/migrations.html.md
+++ b/docsite/source/migrations.html.md
@@ -33,6 +33,24 @@ The following tasks are available:
 * `rake db:clean` - removes all tables
 * `rake db:reset` - removes all tables and re-runs migrations
 
+With the help of the `migration_options` you can apply certain customizations:
+
+``` ruby
+# your rakefile
+
+require 'rom/sql/rake_task'
+
+namespace :db do
+  task :setup do
+    # ROM::SQL::RakeSupport.env = ROM.container(...)
+    ROM::SQL::RakeSupport.migration_options = {
+      table: :custom_table, # defaults to :schema_migrations,
+      column :custom_column, # defaults to :filename
+    }
+  end
+end
+```
+
 ### File-based migrations
 
 Migrations created with a command such as `rake db:create_migration[create_users]` will be placed at under the `db/migrate` folder at the root of your project.

--- a/lib/rom/sql/tasks/migration_tasks.rake
+++ b/lib/rom/sql/tasks/migration_tasks.rake
@@ -10,7 +10,7 @@ module ROM
 
       class << self
         def run_migrations(options = {})
-          gateway.run_migrations(options)
+          gateway.run_migrations(migration_options.merge(options))
         end
 
         def create_migration(*args)
@@ -23,6 +23,13 @@ module ROM
         #
         # @api public
         attr_accessor :env
+
+
+        # Migration options, which are passed to `ROM::SQL::RakeSupport.run_migrations`. You can 
+        # set them in the `db:setup` task with `ROM::SQL::RakeSupport.migration_options = { ... }`
+        #
+        # @api public
+        attr_accessor :migration_options
 
         private
 
@@ -40,6 +47,7 @@ module ROM
       end
 
       @env = nil
+      @migration_options = {}
     end
   end
 end

--- a/spec/unit/migration_tasks_spec.rb
+++ b/spec/unit/migration_tasks_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 namespace :db do
   task :setup do
@@ -6,103 +6,160 @@ namespace :db do
   end
 end
 
-RSpec.describe 'MigrationTasks', :postgres, skip_tables: true do
-  include_context 'database setup'
+RSpec.describe "MigrationTasks", :postgres, skip_tables: true do
+  include_context "database setup"
 
   let(:migrator) { container.gateways[:default].migrator }
+  let(:task) { nil }
 
   before do
     ROM::SQL::Gateway.instance = nil
     ROM::SQL::RakeSupport.env = nil
+    ROM::SQL::RakeSupport.migration_options = {}
     conf
   end
 
-  context 'db:reset' do
-    it 'calls proper commands' do
+  after(:each) do
+    task.reenable
+  end
+
+  context "db:reset" do
+    let(:task) { Rake::Task["db:reset"] }
+
+    it "calls proper commands" do
       expect(migrator).to receive(:run).with(target: 0)
       expect(migrator).to receive(:run)
 
       expect {
-        Rake::Task["db:reset"].invoke
+        task.invoke
       }.to output("<= db:reset executed\n").to_stdout
+    end
+
+    context "with custom migration_options" do
+      before do
+        ROM::SQL::RakeSupport.migration_options = { table: :custom_table, column: :custom_column }
+      end
+
+      it "calls proper commands" do
+        expect(migrator).to receive(:run).with(target: 0, table: :custom_table, column: :custom_column)
+        expect(migrator).to receive(:run).with(table: :custom_table, column: :custom_column)
+  
+        expect {
+          task.invoke
+        }.to output("<= db:reset executed\n").to_stdout
+      end
     end
   end
 
-  context 'db:migrate' do
-    context 'with VERSION' do
-      it 'calls proper commands' do
+  context "db:migrate" do
+    let(:task) { Rake::Task["db:migrate"] }
+
+    context "with VERSION" do
+      it "calls proper commands" do
         expect(migrator).to receive(:run).with(target: 1)
 
         expect {
-          Rake::Task["db:migrate"].invoke(1)
+          task.invoke(1)
         }.to output("<= db:migrate version=[1] executed\n").to_stdout
       end
     end
 
-    context 'without VERSION' do
-      it 'calls proper commands' do
+    context "without VERSION" do
+      it "calls proper commands" do
         expect(migrator).to receive(:run)
 
         expect {
-          Rake::Task["db:migrate"].execute
+          task.execute
         }.to output("<= db:migrate executed\n").to_stdout
       end
     end
 
-    it 'raises an error on missing both env and Gateway.instance' do
+    it "raises an error on missing both env and Gateway.instance" do
       ROM::SQL::RakeSupport.env = nil
       ROM::SQL::Gateway.instance = nil
 
       expect {
-        Rake::Task["db:migrate"].execute
+        task.execute
       }.to raise_error(ROM::SQL::RakeSupport::MissingEnv)
+    end
+
+    context "with custom migration_options" do
+      before do
+        ROM::SQL::RakeSupport.migration_options = { table: :custom_table, column: :custom_column }
+      end
+
+      it "calls proper commands" do
+        expect(migrator).to receive(:run).with(table: :custom_table, column: :custom_column)
+  
+        expect {
+          task.invoke
+        }.to output("<= db:migrate executed\n").to_stdout
+      end
     end
   end
 
-  context 'db:clean' do
-    it 'calls proper commands' do
+  context "db:clean" do
+    let(:task) { Rake::Task["db:clean"] }
+
+    it "calls proper commands" do
       expect(migrator).to receive(:run).with(target: 0)
 
       expect {
-        Rake::Task["db:clean"].invoke
+        task.invoke
       }.to output("<= db:clean executed\n").to_stdout
+    end
+
+    context "with custom migration_options" do
+      before do
+        ROM::SQL::RakeSupport.migration_options = { table: :custom_table, column: :custom_column }
+      end
+
+      it "calls proper commands" do
+        expect(migrator).to receive(:run).with(target: 0, table: :custom_table, column: :custom_column)
+  
+        expect {
+          task.invoke
+        }.to output("<= db:clean executed\n").to_stdout
+      end
     end
   end
 
-  context 'db:create_migration' do
-    context 'without NAME' do
-      it 'exit without creating any file' do
+  context "db:create_migration" do
+    let(:task) { Rake::Task["db:create_migration"] }
+
+    context "without NAME" do
+      it "exit without creating any file" do
         expect(File).to_not receive(:write)
 
         expect {
           expect {
-            Rake::Task["db:create_migration"].execute
+            task.execute
           }.to output(/No NAME specified/).to_stdout
         }.to raise_error(SystemExit)
       end
     end
 
-    context 'with NAME' do
-      let(:dirname) { 'tmp/db/migrate' }
-      let(:name) { 'foo_bar' }
-      let(:version) { '001' }
+    context "with NAME" do
+      let(:dirname) { "tmp/db/migrate" }
+      let(:name) { "foo_bar" }
+      let(:version) { "001" }
       let(:filename) { "#{version}_#{name}.rb" }
       let(:path) { File.join(dirname, filename) }
 
-      it 'calls proper commands with default VERSION' do
+      it "calls proper commands with default VERSION" do
         expect(migrator).to receive(:create_file).with(name).and_return(path)
 
         expect {
-          Rake::Task["db:create_migration"].execute(
+          task.execute(
             Rake::TaskArguments.new([:name], [name]))
         }.to output("<= migration file created #{path}\n").to_stdout
       end
 
-      it 'calls proper commands with manualy set VERSION' do
+      it "calls proper commands with manualy set VERSION" do
         expect(migrator).to receive(:create_file).with(name, version).and_return(path)
 
         expect {
-          Rake::Task["db:create_migration"].execute(
+          task.execute(
             Rake::TaskArguments.new([:name, :version], [name, version]))
         }.to output("<= migration file created #{path}\n").to_stdout
       end


### PR DESCRIPTION
Hey,
I want to use the default rake migration tasks, but need to customize the table opt. This PR would fix my need.

thanks and best regards
