### PR TITLE
Document `:as` option for `schema`

### DIFF
--- a/docsite/source/schemas.html.md
+++ b/docsite/source/schemas.html.md
@@ -43,6 +43,18 @@ posts.by_pk(1).one
 # => {:id => 1, :title => "Hello World", status: :draft }
 ```
 
+## Relation Alias
+
+If you want to refer to your relation by a different name you can use `:as`:
+
+```ruby
+require 'rom-sql'
+
+class Users < ROM::Relation[:sql]
+  schema(as: :legacy_users, infer: true) # that's it
+end
+```
+
 ## PostgreSQL Types
 
 When you define relation schema attributes using custom PG types, the values


### PR DESCRIPTION
If we are migrating from a legacy database to a new one, we might want
to use a different name to refer to database tables in the legacy
database even though the new database has the same table names.

The `:as` option allows us to do this but because we couldn't find any
documentation for how to use it in `rom-sql`, we have added an example.

An example of our use case:

```ruby
module MyApp
  module Relations
    module Legacy
      class Video < ROM::Relation[:sql]
        gateway(:legacy)

        schema(:videos, as: :legacy_videos, infer: true)
      end
    end
  end

  module Repositories
    module Legacy
      class Video < MyApp::Repository[:legacy_videos]
      end
    end
  end
end
```

Co-authored-by: Steven Chudley <steven.chudley@gmail.com>