### PR TITLE
Remove Ruby 2.7 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         ruby:
         - '3.1'
         - '3.0'
-        - '2.7'
         include:
         - ruby: '3.1'
           coverage: 'true'


### PR DESCRIPTION
This is causing #419 to fail because every version of dry-transformer
depends on Ruby >= 3.0.0

Co-authored-by: Steven Chudley <steven.chudley@gmail.com>