### PR TITLE
Fix excessive logging by instrumentation plugin

### DIFF
--- a/spec/unit/relation/instrument_spec.rb
+++ b/spec/unit/relation/instrument_spec.rb
@@ -64,4 +64,30 @@ RSpec.describe ROM::SQL::Relation, '#instrument', :sqlite do
     expect(notifications.logs).
       to include([:sql, name: :sqlite, query: "SELECT count(*) AS 'count' FROM `users` LIMIT 1"])
   end
+
+  context 'two containers with shared gateway' do
+    let(:conf_alt) { TestConfiguration.new(:sql, conn) }
+
+    let(:container_alt) { ROM.container(conf_alt) }
+
+    before do
+      conf_alt.plugin(:sql, relations: :instrumentation)
+
+      conf_alt.relation(:users) do
+        schema(infer: true)
+      end
+
+      container_alt
+    end
+
+    it 'instruments relation materialization but does it once' do
+      relation.to_a
+
+      entries = notifications.logs.count do |log|
+        log.eql?([:sql, name: :sqlite, query: relation.dataset.sql])
+      end
+
+      expect(entries).to be(1)
+    end
+  end
 end


### PR DESCRIPTION
It happens when there's more than one container using the same gateway. This issue is already fixed in the main branch, I'll add the spec there, though