### PR TITLE
Support table aliases on associated relations

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -1107,6 +1107,8 @@ module ROM
               end
 
               new(dataset.__send__(type, other.name.dataset.to_sym, join_cond, join_opts))
+            elsif opts[:table_alias]
+              new(dataset.__send__( type, other.name.key, join_cond, opts))
             else
               associations[other.name.key].join(type, self, other)
             end

--- a/spec/unit/relation/inner_join_spec.rb
+++ b/spec/unit/relation/inner_join_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ROM::Relation, '#inner_join' do
                                  ])
     end
 
-    it 'allows specifying table_aliases' do
+    it 'allows specifying table_alias with table name' do
       relation.insert id: 3, name: 'Jade'
 
       result = relation
@@ -192,6 +192,32 @@ RSpec.describe ROM::Relation, '#inner_join' do
         result = puzzles.inner_join(users).select(users[:name], puzzles[:text])
 
         expect(result.to_a).to eql([name: 'Jane', text: 'solved by Jane'])
+      end
+
+      it 'allows specifying table_alias with association name' do
+        result = relation
+                .inner_join(:tasks, { user_id: :id }, table_alias: :t1)
+                .select(:name, tasks[:title].qualified(:t1))
+
+        expect(result.schema.map(&:name)).to eql(%i[name title])
+
+        expect(result.to_a).to eql([
+                                    { name: 'Jane', title: "Jane's task" },
+                                    { name: 'Joe', title: "Joe's task" }
+                                  ])
+      end
+
+      it 'allows specifying table_alias with relation' do
+        result = relation
+                .inner_join(tasks, { user_id: :id }, table_alias: :requirements)
+                .select(:name, tasks[:title].qualified(:requirements))
+
+        expect(result.schema.map(&:name)).to eql(%i[name title])
+
+        expect(result.to_a).to eql([
+                                    { name: 'Jane', title: "Jane's task" },
+                                    { name: 'Joe', title: "Joe's task" }
+                                  ])
       end
     end
   end


### PR DESCRIPTION
I discovered this bug the other week. If you call `join` with a relation object, `table_alias` doesn't work at all. It only works with the name a symbol.