### PR TITLE
Fix inconsistent behaviour across adapters with read types and "create" command

### DIFF
--- a/lib/rom/sql/commands/create.rb
+++ b/lib/rom/sql/commands/create.rb
@@ -46,7 +46,7 @@ module ROM
         # @api private
         def insert(tuples)
           pks = tuples.map { |tuple| relation.insert(tuple) }
-          relation.where(relation.primary_key => pks).to_a
+          relation.dataset.where(relation.primary_key => pks).to_a
         end
 
         # Executes multi_insert statement and returns inserted tuples
@@ -54,7 +54,7 @@ module ROM
         # @api private
         def multi_insert(tuples)
           pks = relation.multi_insert(tuples, return: :primary_key)
-          relation.where(relation.primary_key => pks).to_a
+          relation.dataset.where(relation.primary_key => pks).to_a
         end
 
         # Yields tuples for insertion or return an enumerator

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe 'Commands / Create', :postgres, seeds: false do
       }.to raise_error(ROM::SQL::NotNullConstraintError)
     end
 
+    context 'with json notes' do
+      include_context 'json_notes'
+
+      before do
+        conf.commands(:json_notes) do
+          define(:create)
+        end
+      end
+
+      it 'writes and reads back custom type' do
+        json_notes = commands[:json_notes]
+
+        expect(json_notes[:create].call(note: 'this is my note')).to eq([{id: 1, note: 'this is my note'}])
+      end
+    end
+
     # Because Oracle doesn't have boolean in SQL
     unless metadata[:oracle]
       context 'with puppies' do

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -110,6 +110,25 @@ RSpec.describe 'Commands / Update', seeds: false do
           { id: 2, name: 'Josie' }
         ])
       end
+
+      context "with json notes" do
+        include_context "json_notes"
+
+        before do
+          conf.commands(:json_notes) do
+            define(:update)
+          end
+        end
+
+        let(:json_notes) { container.relations[:json_notes] }
+
+        it "writes and reads back custom type" do
+          note_id = conn[:json_notes].insert(note: "note version 1")
+          result = json_notes.by_pk(note_id).command(:update).call(note: "note version 2")
+
+          expect(result).to eq([{id: 1, note: "note version 2"}])
+        end
+      end
     end
   end
 end

--- a/spec/shared/json_notes.rb
+++ b/spec/shared/json_notes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "json_notes" do
+  before do
+    inferrable_relations.concat %i[json_notes]
+  end
+
+  before do |_example|
+    conn.create_table :json_notes do
+      primary_key :id
+      String :note
+    end
+
+    write_type = Dry.Types.Constructor(String) { |value| JSON.dump({content: value}) }
+    read_type = Dry.Types.Constructor(String) { |value| JSON.parse(value)["content"] }
+
+    conf.relation(:json_notes) do
+      schema(infer: true) do
+        attribute :note, write_type, read: read_type
+      end
+    end
+  end
+end


### PR DESCRIPTION
During the investigation for #423 I discovered that for SQLite and MySQL (or basically for everything aside from PostgreSQL) the read types are applied twice. This works well if the read type allows it, but if it does not, it fails for these adapters, making behaviour between adapter inconsistent.

The solution here is to use `relation.dataset.where` instead of `relation.where` in default implementation of `insert` method of `Create` command. `relation.where` already applies the read types on materialization, while `relation.dataset.where` does not. This is also consistent with how `Update` command behaves.

With that in place, we always call `finalize` on "raw" data from the database, avoiding double application of a read type.

The PR consists of two commits. First one just adds tests replicating the problem. The second one just changes the code.