### PR TITLE
Fix docs for left and right join

### DIFF
--- a/lib/rom/sql/relation/reading.rb
+++ b/lib/rom/sql/relation/reading.rb
@@ -627,7 +627,7 @@ module ROM
         #
         #   @param [Relation] relation A relation for left_join
         #
-        # @overload join(relation, &block)
+        # @overload left_join(relation, &block)
         #   Join with another relation using DSL
         #
         #   @example
@@ -676,7 +676,7 @@ module ROM
         #
         #   @param [Relation] relation A relation for right_join
         #
-        # @overload join(relation, &block)
+        # @overload right_join(relation, &block)
         #   Join with another relation using DSL
         #
         #   @example


### PR DESCRIPTION
Very small fix to the docs, which defined an overload for a wrong function.