### PR TITLE
Fix warning issued by AS log subscriber 7.1 and make bold again

### DIFF
--- a/lib/rom/sql/extensions/rails_log_subscriber.rb
+++ b/lib/rom/sql/extensions/rails_log_subscriber.rb
@@ -14,8 +14,8 @@ module ROM
         end
 
       COLOR_OPTION =
-        if as_version && as_version >= ::Gem::Version.new('7.2')
-          { color: true }
+        if as_version && as_version >= ::Gem::Version.new('7.1.2')
+          { bold: true }
         else
           true
         end


### PR DESCRIPTION
Fixed for 7.2 in https://github.com/rom-rb/rom-sql/commit/62867221448f657519cd4526a725d81e9dfed697

But the warning is already present from rails 7.1.2 (7.2 is even an error, not a warning).

The previous fix turned the positional boolean into `{color: true}`, but the only keys that do anything are bold/italic/underline, and the old true stood for bold, see: https://github.com/rails/rails/blob/v7.1.5.2/activesupport/lib/active_support/log_subscriber.rb#L190 and https://github.com/rails/rails/blob/v7.1.5.2/activesupport/lib/active_support/log_subscriber.rb#L70

Arguments remain the same for for 7.2 https://github.com/rails/rails/blob/v7.2.2.2/activesupport/lib/active_support/log_subscriber.rb#L170 and 8.0 https://github.com/rails/rails/blob/v7.2.2.2/activesupport/lib/active_support/log_subscriber.rb#L170

No spec changes, since there is no appraisals, nor any existing specs around this.