### PR TITLE
Support plain SQL migrations

### DIFF
--- a/lib/rom/sql/errors.rb
+++ b/lib/rom/sql/errors.rb
@@ -19,6 +19,8 @@ module ROM
     MissingPrimaryKeyError    = Class.new(StandardError)
     MigrationError            = Class.new(StandardError)
     UnsupportedConversion     = Class.new(MigrationError)
+    SQLParseError             = Class.new(MigrationError)
+    SQLEnvError               = Class.new(MigrationError)
 
     ERROR_MAP = {
       Sequel::DatabaseError => DatabaseError,

--- a/lib/rom/sql/migration/migrator.rb
+++ b/lib/rom/sql/migration/migrator.rb
@@ -9,6 +9,8 @@ require 'rom/sql/migration/runner'
 require 'rom/sql/migration/inline_runner'
 require 'rom/sql/migration/writer'
 
+Sequel.extension :sql_migrations
+
 module ROM
   module SQL
     module Migration

--- a/lib/rom/sql/migration/sql_migration.rb
+++ b/lib/rom/sql/migration/sql_migration.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "dry/struct"
+
+require "rom/sql/types"
+
+module ROM
+  module SQL
+    module Migration
+      # A single executable statement extracted from a `.sql` migration
+      # section, paired with the source line where it begins. The line is
+      # used to annotate backtraces when execution fails.
+      #
+      # @api private
+      Statement = Data.define(:sql, :line)
+
+      # A migration translated from a `.sql` file by `SQLParser`.
+      #
+      # @api private
+      class SQLMigration < Dry::Struct
+        Filename   = Types::Coercible::String
+        Settings   = Types::Strict::Hash.default { {} }
+        Direction  = Types::Strict::Symbol.enum(:up, :down)
+        Statements = Types::Array.of(Types.Instance(Statement))
+
+        # Matches `${NAME}` substitution references in statement bodies when the
+        # `env=true` pragma is set. Only the braced form is recognized, leaving
+        # `$$`-quoted bodies and `$1` positional params untouched.
+        SUBSTITUTION = /\$\{(?<name>[A-Za-z_]\w*)\}/
+
+        attribute :filename, Filename
+        attribute :settings, Settings
+
+        attribute :up, Statements
+        attribute? :down, Statements
+
+        # Return a copy with additional settings merged in.
+        #
+        # @api private
+        def with(**settings)
+          new(settings: self.settings.merge(settings))
+        end
+
+        # Whether to run inside a transaction.
+        #
+        # @return [true, false, nil] nil leaves the choice to the database default
+        #
+        # @api private
+        def use_transactions
+          settings[:transaction]
+        end
+
+        # Execute the statements for the given direction against the database.
+        #
+        # @param db [Sequel::Database]
+        # @param direction [:up, :down]
+        #
+        # @api private
+        def apply(db, direction)
+          unless Direction.valid?(direction)
+            raise ArgumentError, "Invalid migration direction specified (#{direction.inspect})"
+          end
+
+          statements = public_send(direction) or return
+
+          # Resolve every statement before running any, so a missing environment
+          # variable aborts before producing side effects.
+          finalized = statements.map { |statement| sub(statement) }
+
+          finalized.each do |statement|
+            db.run(statement.sql)
+          rescue Sequel::DatabaseError => e
+            raise annotate(e, statement, direction)
+          end
+        end
+
+        private
+
+        # Return the statement with `${NAME}` environment-variable substitution
+        # applied to its SQL when the `env` pragma is set. Raises `SQLEnvError`
+        # for a referenced variable that is not present in `ENV`.
+        #
+        # @api private
+        def sub(statement)
+          return statement unless settings[:env]
+
+          sql = statement.sql.gsub(SUBSTITUTION) do
+            name = Regexp.last_match[:name]
+            ENV.fetch(name) do
+              raise SQLEnvError,
+                    "Undefined environment variable ${#{name}} in #{filename}:#{statement.line}"
+            end
+          end
+
+          statement.with(sql:)
+        end
+
+        # Prepend a synthetic frame pointing at the failing statement's source
+        # location, so the migration file appears at the top of the backtrace.
+        #
+        # @api private
+        def annotate(error, statement, direction)
+          frame = "#{filename}:#{statement.line}:in '#{direction}'"
+          error.set_backtrace([frame, *(error.backtrace || [])])
+          error
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/sql/migration/sql_parser.rb
+++ b/lib/rom/sql/migration/sql_parser.rb
@@ -1,0 +1,393 @@
+# frozen_string_literal: true
+
+require_relative "sql_migration"
+
+module ROM
+  module SQL
+    module Migration
+      # SQL migrations have a very simple grammar:
+      #
+      # 1. Files are organized into two directions (up and down). Each
+      #    direction may contain one or more `begin..end` sections; all
+      #    sections for a direction execute sequentially in source order
+      #    at apply time. Each section keeps its own `split=` setting,
+      #    so a single direction may mix splitting strategies across
+      #    sections.
+      # 2. Directives are written as SQL line comments using the `-- @migrate`
+      #    sigil. The leading `--` keeps directive lines valid SQL syntax (so
+      #    editors, syntax highlighters, and linters treat them as comments);
+      #    the `@migrate` sigil disambiguates them from author-written `--`
+      #    comments. Plain `-- ...` comments without the `@migrate` sigil are
+      #    treated as part of the SQL body and pass through verbatim.
+      # 3. Optional settings may be provided in a pragma line before the up/down sections
+      # 4. Pragma and begin lines accept `key=value` settings separated by spaces or tabs
+      # 5. Each direction begins with a direction directive followed by one
+      #    or more begin directives
+      # 6. The begin directive may itself carry settings (e.g. statement splitting strategy)
+      # 7. Each section concludes with an end directive
+      # 8. Down migrations are optional, but they always must follow the up migration
+      # 9. Empty sections (begin..end with no SQL body) are silently skipped
+      #
+      # Recognized settings:
+      #
+      # * Pragma line: `transaction=true|false` controls whether the migration runs
+      #   inside a transaction. Any other value raises `SQLParseError`. Unknown
+      #   pragma keys are silently ignored.
+      # * Pragma line: `env=true|false` enables environment-variable substitution
+      #   in statement bodies (see "Variable substitution"). Any other value raises
+      #   `SQLParseError`.
+      # * Begin line: `split=semicolon|line` controls statement splitting for the
+      #   section's body. Default is to send the entire body to the database in a
+      #   single call. Any other value raises `SQLParseError`. Unknown begin keys
+      #   are silently ignored.
+      #
+      # Variable substitution:
+      #
+      # * With the `env=true` pragma, occurrences of `${NAME}` in statement bodies
+      #   are replaced with `ENV["NAME"]` when the migration is applied. Names match
+      #   `[A-Za-z_][A-Za-z0-9_]*`.
+      # * Only the braced form `${NAME}` is substituted. Bare `$NAME`, `$$`-quoted
+      #   bodies, and `$1` positional parameters are left untouched, so the feature
+      #   is safe to use alongside PostgreSQL function bodies and prepared params.
+      # * Substitution happens at apply time, so values reflect the environment when
+      #   the migration runs. All of a direction's statements are resolved before
+      #   any are executed, so a missing variable aborts before any side effects.
+      # * A `${NAME}` with no corresponding `ENV` entry raises `SQLEnvError`.
+      # * Values are inserted as raw SQL text (not quoted or escaped); the
+      #   environment is trusted input.
+      #
+      # Splitting caveats:
+      #
+      # * `split=semicolon` splits on `;` followed by end of line. It does **not**
+      #   track string literals or `$$`-quoted bodies; semicolons inside those will
+      #   be mistaken for statement terminators. Use the default single-statement
+      #   mode for migrations containing such content.
+      # * `split=line` emits each non-empty line as a separate statement. Plain
+      #   SQL comment lines (`-- ...` without the `@migrate` sigil) are passed
+      #   through verbatim and will each be sent to the database as their own
+      #   (no-op) statement.
+      # * Adjacent settings on the same directive line are separated by one or
+      #   more space or tab characters. Trailing whitespace after the last
+      #   setting is allowed. Any other content on a directive line raises
+      #   `SQLParseError`.
+      # * Windows-style line endings (`\r\n`) are normalized to `\n` at read time.
+      # * The directive prefix requires exactly one space between `--` and
+      #   `@migrate` (i.e. `-- @migrate`). A bare `@migrate` at the start of a
+      #   line (no `--` prefix) is treated as SQL content.
+      # * A body line of the form `[whitespace]word=word` is lexed as a setting,
+      #   not SQL. Immediately after a begin directive such a line is consumed as
+      #   a (possibly ignored) section setting rather than emitted as a statement.
+      #
+      # ABNF Grammar (RFC 5234 core rules: ALPHA, DIGIT, SP, HTAB, WSP, LF):
+      #
+      #     ; The format is line-oriented. A blank line (LF alone) yields no
+      #     ; tokens and may appear between any lines; blank lines are omitted
+      #     ; below for clarity. The final line's terminating LF is optional
+      #     ; (EOF may stand in for it).
+      #     ;
+      #     ; Disambiguation is by lexer precedence: each physical line is
+      #     ; matched against the directive, pragma, then setting productions
+      #     ; (in that order); a line matching none of them is a sql-line. ABNF
+      #     ; cannot express that exclusion, so sql-line is descriptive.
+      #
+      #     input          = *pragma-line up-direction [down-direction]
+      #
+      #     up-direction   = up-line   1*sql-section
+      #     down-direction = down-line 1*sql-section
+      #     sql-section    = begin-line *sql-line end-line
+      #
+      #     ; Direction directives take no settings; only trailing whitespace
+      #     ; may follow.
+      #
+      #     up-line   = "-- @migrate up"   trailer newline
+      #     down-line = "-- @migrate down" trailer newline
+      #     end-line  = "-- @migrate end"  trailer newline
+      #
+      #     ; begin and pragma lines may carry whitespace-separated settings.
+      #
+      #     begin-line  = "-- @migrate begin" *( gap setting ) trailer newline
+      #     pragma-line = "-- @migrate"       *( gap setting ) trailer newline
+      #
+      #     setting   = word "=" word
+      #     word      = 1*word-char
+      #     word-char = ALPHA / DIGIT / "_"
+      #     sql-line  = 1*line-char newline
+      #
+      #     ; Terminals
+      #
+      #     newline   = LF
+      #     gap       = 1*WSP             ; whitespace separating settings
+      #     trailer   = *WSP              ; optional trailing whitespace
+      #     line-char = %x01-09 / %x0B-FF ; any byte except LF
+      #
+      # @api private
+      class SQLParser
+        NEWLINE = "\n"
+
+        # Matches a trailing `;` (with optional trailing horizontal whitespace)
+        # at the end of a statement buffer. `split=semicolon` treats an
+        # end-of-line `;` as a statement terminator.
+        SEMICOLON = /;[ \t]*\z/
+
+        # Each TOKENS row is `[type, regex]`. Every regex must include a
+        # `(?<value>...)` named capture identifying the substring that becomes
+        # the token's value and position. The tokenizer reads
+        # `match[:value]` for the value and `match.begin(:value)` for the
+        # column; `lpos` advances by `match.end(0)`, which may exceed the
+        # value's span when the regex consumes more (e.g. leading whitespace
+        # as a separator for the `:setting` regex).
+        #
+        # IMPORTANT: order matters. The `:pragma` regex matches the prefix
+        # of every more-specific directive (`:up`, `:down`, `:begin`,
+        # `:end`). The tokenizer uses first-match-wins, so the specific
+        # directives MUST appear before `:pragma`. When adding a new
+        # `-- @migrate <verb>` directive, insert its row above the `:pragma`
+        # row or it will be silently tokenized as a pragma.
+        TOKENS = [
+          [:up, /\A(?<value>-- @migrate up)\b/i],
+          [:down, /\A(?<value>-- @migrate down)\b/i],
+          [:begin, /\A(?<value>-- @migrate begin)\b/i],
+          [:end, /\A(?<value>-- @migrate end)\b/i],
+          [:pragma, /\A(?<value>-- @migrate)\b/i],
+          [:setting, /\A[ \t]+(?<value>\w+=\w+)\b/i],
+        ]
+
+        TRAILING_WHITESPACE = /\A[ \t]*(?:\n|\z)/
+
+        class Token < String
+          attr_reader :type, :line, :pos
+
+          def initialize(value, type:, line:, pos:)
+            super(value)
+
+            @type = type
+            @line = line
+            @pos  = pos
+
+            freeze
+          end
+
+          def value = to_s
+          def inspect = "(#{type} #{super} @#{line_pos})"
+          def end = pos + length
+          def type?(name) = type == name
+          def line_pos = "#{line}:#{pos}"
+        end
+
+        # Translate a `.sql` migration file into an `SQLMigration`.
+        #
+        # @param path [String, Pathname] absolute path to the `.sql` file
+        # @return [SQLMigration]
+        #
+        # @api private
+        def call(path)
+          @path  = path
+          tokens = File.open(path, "r") { |file| tokenize(file) }
+
+          if tokens.all? { |t| t.type == :line }
+            raise SQLParseError, "No @migrate directives found in #{path}"
+          end
+
+          settings = parse_pragmas(tokens)
+          up       = parse_up(tokens)
+          down     = parse_down(tokens)
+
+          if (stray = tokens.first)
+            raise SQLParseError,
+                  "Unexpected content after final section in #{path}: " \
+                  "#{stray.type} at #{location(path, stray.line, stray.pos)}"
+          end
+
+          attributes = { filename: path, settings:, up:, down: }.compact
+
+          SQLMigration.new(**attributes)
+        end
+
+        def tokenize(file)
+          lno = 0
+          tokens = []
+
+          until file.eof?
+            # Normalize line endings
+            line = file.gets.sub(/\r\n\z/, NEWLINE)
+            lno += 1
+            lpos = 0
+
+            while lpos < line.length
+              remainder = line[lpos..]
+
+              break if remainder == NEWLINE
+
+              match_type, match_data = nil
+              TOKENS.each do |type, regex|
+                if (match = remainder.match(regex))
+                  match_type = type
+                  match_data = match
+                  break
+                end
+              end
+
+              if match_data
+                tokens << Token.new(
+                  match_data[:value],
+                  type: match_type,
+                  line: lno,
+                  pos: lpos + match_data.begin(:value)
+                )
+                lpos += match_data.end(0)
+              elsif lpos.zero?
+                # No directive matched at start of line: treat as a SQL line.
+                tokens << Token.new(line.chomp(NEWLINE), type: :line, line: lno, pos: lpos)
+                lpos = line.length
+              elsif remainder.match?(TRAILING_WHITESPACE)
+                # Trailing whitespace after the last setting on a directive
+                # line is allowed.
+                break
+              else
+                raise SQLParseError,
+                      "Unrecognized content #{remainder.chomp.inspect} " \
+                      "on directive line at #{location(@path, lno, lpos)}"
+              end
+            end
+          end
+
+          tokens
+        end
+
+        def parse_pragmas(tokens)
+          settings = {}
+
+          while next?(:pragma, tokens)
+            consume(:pragma, tokens)
+
+            while next?(:setting, tokens)
+              case parse_setting(tokens)
+              in [:transaction, "true" | "false" => value]
+                settings[:transaction] = value == "true"
+              in [:env, "true" | "false" => value]
+                settings[:env] = value == "true"
+              in [(:transaction | :env) => key, value]
+                raise SQLParseError,
+                      %(#{key}= must be "true" or "false", got #{value.inspect} in #{@path})
+              else
+                # ignore unknown pragma keys
+              end
+            end
+          end
+
+          settings
+        end
+
+        def parse_settings(tokens)
+          settings = {}
+
+          while next?(:setting, tokens)
+            key, value = parse_setting(tokens)
+            settings[key] = value
+          end
+
+          settings
+        end
+
+        def parse_setting(tokens)
+          key, value = consume(:setting, tokens).value.split("=", 2)
+          [key.to_sym, value]
+        end
+
+        def parse_up(tokens)
+          consume(:up, tokens)
+          parse_sections(tokens)
+        end
+
+        def parse_down(tokens)
+          return unless next?(:down, tokens)
+
+          consume(:down, tokens)
+          parse_sections(tokens)
+        end
+
+        # Parse one or more consecutive `-- @migrate begin..end` sections for
+        # the current direction and return their statements as a single flat
+        # array.
+        #
+        # @api private
+        def parse_sections(tokens)
+          statements = parse_sql(tokens)
+
+          while next?(:begin, tokens)
+            statements += parse_sql(tokens)
+          end
+
+          statements
+        end
+
+        # Parse a single `begin..end` section into an array of `Statement`s,
+        # applying the section's `split=` strategy.
+        #
+        # @api private
+        def parse_sql(tokens)
+          consume(:begin, tokens)
+          settings = parse_settings(tokens)
+
+          line_tokens = []
+
+          while next?(:line, tokens)
+            line_tokens << consume(:line, tokens)
+          end
+
+          consume(:end, tokens)
+
+          return [] if line_tokens.empty?
+
+          case settings.fetch(:split, :absent)
+          when :absent
+            [Statement.new(sql: join(line_tokens), line: line_tokens.first.line)]
+          when "line"
+            line_tokens
+              .reject { |token| token.value.strip.empty? }
+              .map { |token| Statement.new(sql: token.value, line: token.line) }
+          when "semicolon"
+            line_tokens
+              .slice_after { |token| token.value.match?(SEMICOLON) }
+              .filter_map { |group|
+                sql = join(group).sub(SEMICOLON, "")
+                Statement.new(sql: sql, line: group.first.line) unless sql.strip.empty?
+              }
+          else
+            raise SQLParseError, %(Unknown split strategy #{settings[:split].inspect}: expected "semicolon" or "line" in #{@path})
+          end
+        end
+
+        # Join line tokens back into a single SQL string.
+        #
+        # @api private
+        def join(line_tokens)
+          line_tokens.map(&:value).join(NEWLINE)
+        end
+
+        def next?(type, tokens)
+          return false if tokens.empty?
+
+          tokens.first.type?(type)
+        end
+
+        def consume(type, tokens)
+          if next?(type, tokens)
+            tokens.shift
+          elsif tokens.empty?
+            raise SQLParseError,
+                  "Unexpected end of input in #{@path}, " \
+                  "expected token of type #{type.inspect}"
+          else
+            token = tokens[0]
+            raise SQLParseError,
+                  "Expected #{type}, got #{token.type} " \
+                  "at #{location(@path, token.line, token.pos)}"
+          end
+        end
+
+        def location(path, line, col) = "#{path}:#{line}:#{col}"
+      end
+    end
+  end
+end

--- a/lib/sequel/extensions/sql_migrations.rb
+++ b/lib/sequel/extensions/sql_migrations.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+# Once loaded, all Sequel migrators in the process will accept `.sql` files
+# alongside `.rb` files. `.sql` files are translated into
+# `ROM::SQL::Migration::SQLMigration` instances by `ROM::SQL::Migration::SQLParser`,
+# satisfying the same `apply(db, direction)` contract that Sequel's runner
+# uses for all migrations.
+#
+# The extension uses `Module#prepend` to override the small set of methods
+# in `Sequel::Migrator` and its subclasses that consult the hardcoded
+# `MIGRATION_FILE_PATTERN`. Sequel's own `Migrator.migrator_class`
+# integer-vs-timestamp selection logic is preserved.
+
+Sequel.extension :migration
+
+require "rom/sql/migration/sql_parser"
+
+module ROM
+  module SQL
+    module Migration
+      # @api private
+      module SequelExtension
+        # Replacement for `Sequel::Migrator::MIGRATION_FILE_PATTERN` that
+        # additionally accepts `.sql` files.
+        MIGRATION_FILE_PATTERN = /\A(\d+)_(.+)\.(rb|sql)\z/i.freeze
+
+        # @api private
+        module FileLoader
+          private
+
+          # @api private
+          def load_migration_file(file)
+            case File.extname(file).downcase
+            when ".sql"
+              sql_parser.call(file)
+            else
+              super
+            end
+          end
+
+          def sql_parser
+            @sql_parser ||= ROM::SQL::Migration::SQLParser.new
+          end
+        end
+
+        # Prepended into `Sequel::Migrator`'s singleton class. Replaces the
+        # `migrator_class` selector so the extension-aware pattern is used
+        # when sniffing the directory for integer-vs-timestamp selection.
+        #
+        # @api private
+        module MigratorClassSelector
+          # @api private
+          def migrator_class(directory)
+            if equal?(Sequel::Migrator)
+              raise Sequel::Migrator::Error, "Must supply a valid migration path" unless File.directory?(directory)
+
+              Dir.new(directory).each do |file|
+                next unless MIGRATION_FILE_PATTERN.match(file)
+                return Sequel::TimestampMigrator if file.split("_", 2).first.to_i > 20000101
+              end
+
+              Sequel::IntegerMigrator
+            else
+              self
+            end
+          end
+        end
+
+        # Prepended into `Sequel::IntegerMigrator`. Re-implements
+        # `get_migration_files` against the extension-aware pattern.
+        #
+        # @api private
+        module IntegerMigratorFiles
+          private
+
+          # @api private
+          def get_migration_files
+            files = []
+            Dir.new(directory).each do |file|
+              next unless MIGRATION_FILE_PATTERN.match(file)
+
+              version = migration_version_from_file(file)
+              if version >= 20000101
+                raise Sequel::Migrator::Error,
+                      "Migration number too large, must use TimestampMigrator: #{file}"
+              end
+              if files[version]
+                raise Sequel::Migrator::Error, "Duplicate migration version: #{version}"
+              end
+
+              files[version] = File.join(directory, file)
+            end
+            unless @allow_missing_migration_files
+              1.upto(files.length - 1) do |i|
+                raise Sequel::Migrator::Error, "Missing migration version: #{i}" unless files[i]
+              end
+            end
+            files
+          end
+        end
+
+        # Prepended into `Sequel::TimestampMigrator`. Re-implements
+        # `get_migration_files` and `split_migration_filename` against the
+        # extension-aware pattern.
+        #
+        # @api private
+        module TimestampMigratorFiles
+          private
+
+          # @api private
+          def get_migration_files
+            files = []
+            Dir.new(directory).each do |file|
+              next unless MIGRATION_FILE_PATTERN.match(file)
+
+              files << File.join(directory, file)
+            end
+            files.sort! do |a, b|
+              a_ver, a_name = split_migration_filename(a)
+              b_ver, b_name = split_migration_filename(b)
+              x = a_ver <=> b_ver
+              x = a_name <=> b_name if x.zero?
+              x
+            end
+            files
+          end
+
+          # @api private
+          def split_migration_filename(path)
+            version, name, = MIGRATION_FILE_PATTERN
+                               .match(File.basename(path))
+                               .captures
+            [version.to_i, name]
+          end
+        end
+      end
+    end
+  end
+end
+
+Sequel::Migrator.prepend(ROM::SQL::Migration::SequelExtension::FileLoader)
+Sequel::Migrator.singleton_class.prepend(ROM::SQL::Migration::SequelExtension::MigratorClassSelector)
+Sequel::IntegerMigrator.prepend(ROM::SQL::Migration::SequelExtension::IntegerMigratorFiles)
+Sequel::TimestampMigrator.prepend(ROM::SQL::Migration::SequelExtension::TimestampMigratorFiles)

--- a/spec/unit/sql_migration_spec.rb
+++ b/spec/unit/sql_migration_spec.rb
@@ -1,0 +1,710 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe ROM::SQL::Migration::SQLParser do
+  subject(:parser) { described_class.new }
+
+  let(:db) { Sequel.sqlite }
+
+  # Write `content` to a temporary `.sql` file and yield its path.
+  def with_sql(content)
+    Tempfile.create(["migration", ".sql"]) do |file|
+      file.binmode
+      file.write(content)
+      file.flush
+      yield file.path
+    end
+  end
+
+  describe "default single-statement section" do
+    it "sends the entire body as one statement and applies up" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE alpha (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:alpha)
+      end
+    end
+  end
+
+  describe "split=semicolon" do
+    it "splits on `;` at end of line and runs each statement separately" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=semicolon
+        CREATE TABLE beta (id INTEGER PRIMARY KEY);
+        CREATE TABLE gamma (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:beta, :gamma)
+      end
+    end
+
+    it "treats the trailing `;` on the final statement as optional" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=semicolon
+        CREATE TABLE mu (id INTEGER PRIMARY KEY);
+        CREATE TABLE nu (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:mu, :nu)
+      end
+    end
+  end
+
+  describe "split=line" do
+    it "emits each non-empty line as a separate statement" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=line
+        CREATE TABLE delta (id INTEGER PRIMARY KEY)
+        CREATE TABLE epsilon (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:delta, :epsilon)
+      end
+    end
+  end
+
+  describe "transaction= pragma" do
+    it "sets use_transactions=true for transaction=true" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate transaction=true
+        -- @migrate up
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect(parser.call(path).use_transactions).to be(true)
+      end
+    end
+
+    it "sets use_transactions=false for transaction=false" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate transaction=false
+        -- @migrate up
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect(parser.call(path).use_transactions).to be(false)
+      end
+    end
+
+    it "raises SQLParseError on an invalid value" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate transaction=maybe
+        -- @migrate up
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /transaction= must be "true" or "false"/
+        )
+      end
+    end
+  end
+
+  describe "unknown settings" do
+    it "silently ignores unknown pragma keys" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate foo=bar
+        -- @migrate up
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.not_to raise_error
+      end
+    end
+
+    it "silently ignores unknown begin-directive keys" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin foo=bar
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "directive-line correctness" do
+    it "raises on stray text before a setting" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin foo bar=baz
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /Unrecognized content/
+        )
+      end
+    end
+
+    it "raises when a colon is used instead of equals in a setting" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split:semicolon
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /Unrecognized content/
+        )
+      end
+    end
+
+    it "raises when a setting is missing its value" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /Unrecognized content/
+        )
+      end
+    end
+
+    it "raises on an unknown split strategy" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=chunks
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /Unknown split strategy/
+        )
+      end
+    end
+  end
+
+  describe "directive-line whitespace handling" do
+    it "accepts multiple space characters between directive and setting" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin   split=semicolon
+        CREATE TABLE zeta (id INTEGER PRIMARY KEY);
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:zeta)
+      end
+    end
+
+    it "accepts a tab as separator" do
+      source = "-- @migrate up\n-- @migrate begin\tsplit=line\nSELECT 1\n-- @migrate end\n"
+
+      with_sql(source) do |path|
+        expect { parser.call(path) }.not_to raise_error
+      end
+    end
+
+    it "allows trailing whitespace after the last setting" do
+      source = "-- @migrate up\n-- @migrate begin split=line   \nSELECT 1\n-- @migrate end\n"
+
+      with_sql(source) do |path|
+        expect { parser.call(path) }.not_to raise_error
+      end
+    end
+
+    it "allows trailing whitespace after a bare directive" do
+      source = "-- @migrate up   \n-- @migrate begin\nSELECT 1\n-- @migrate end\n"
+
+      with_sql(source) do |path|
+        expect { parser.call(path) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "CRLF line endings" do
+    let(:crlf_source) do
+      "-- @migrate up\r\n" \
+      "-- @migrate begin\r\n" \
+      "CREATE TABLE eta (id INTEGER PRIMARY KEY)\r\n" \
+      "-- @migrate end\r\n"
+    end
+
+    it "parses directive lines and applies cleanly" do
+      with_sql(crlf_source) do |path|
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:eta)
+      end
+    end
+
+    it "produces :line tokens without trailing \\r" do
+      with_sql(crlf_source) do |path|
+        tokens = File.open(path, "rb") { |f| parser.tokenize(f) }
+        line_values = tokens.select { |t| t.type == :line }.map(&:value)
+
+        expect(line_values).to all(satisfy { |v| !v.include?("\r") })
+      end
+    end
+
+    it "emits no spurious :line tokens for blank CRLF lines" do
+      source = "-- @migrate up\r\n" \
+               "-- @migrate begin\r\n" \
+               "\r\n" \
+               "SELECT 1\r\n" \
+               "-- @migrate end\r\n"
+
+      with_sql(source) do |path|
+        tokens = File.open(path, "rb") { |f| parser.tokenize(f) }
+        line_values = tokens.select { |t| t.type == :line }.map(&:value)
+
+        expect(line_values).to eq(["SELECT 1"])
+      end
+    end
+  end
+
+  describe "token position fidelity" do
+    it "points :setting tokens at the start of the key, not the leading whitespace" do
+      source = "-- @migrate up\n-- @migrate begin   split=semicolon\nSELECT 1\n-- @migrate end\n"
+
+      with_sql(source) do |path|
+        tokens = File.open(path) { |f| parser.tokenize(f) }
+        setting = tokens.find { |t| t.type == :setting }
+
+        # "-- @migrate begin" (17) + 3 spaces = col 20
+        expect(setting).to have_attributes(value: "split=semicolon", pos: 20)
+      end
+    end
+  end
+
+  describe "error messages" do
+    it "includes the file path on a directive-line parse error" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split:colon
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /#{Regexp.escape(path)}/
+        )
+      end
+    end
+
+    it "includes the file path on a transaction-value error" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate transaction=maybe
+        -- @migrate up
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /#{Regexp.escape(path)}/
+        )
+      end
+    end
+
+    it "includes the file path on a split-strategy error" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=chunks
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /#{Regexp.escape(path)}/
+        )
+      end
+    end
+  end
+
+  describe "empty or content-only files" do
+    it "raises a friendly error for an empty file" do
+      with_sql("") do |path|
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /No @migrate directives found/
+        )
+      end
+    end
+
+    it "raises a friendly error for a file containing only SQL content" do
+      with_sql(<<~SQL) do |path|
+        -- this file has plain SQL comments
+        SELECT 1;
+        -- but no @migrate directives
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /No @migrate directives found/
+        )
+      end
+    end
+  end
+
+  describe "trailing content after the final section" do
+    it "raises when a second up section follows the first" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE x (id INTEGER PRIMARY KEY)
+        -- @migrate end
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE y (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /Unexpected content after final section/
+        )
+      end
+    end
+  end
+
+  describe "multiple sections per direction" do
+    it "runs two consecutive up sections with different split settings" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE foo (id INTEGER PRIMARY KEY, val INTEGER)
+        -- @migrate end
+        -- @migrate begin split=semicolon
+        INSERT INTO foo VALUES (1, 10);
+        INSERT INTO foo VALUES (2, 20);
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+
+        expect(db.tables).to include(:foo)
+        expect(db[:foo].order(:id).all).to eq([
+          {id: 1, val: 10},
+          {id: 2, val: 20}
+        ])
+      end
+    end
+
+    it "supports multi-section up and multi-section down through a full lifecycle" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE foo (id INTEGER PRIMARY KEY)
+        -- @migrate end
+        -- @migrate begin
+        CREATE INDEX foo_idx ON foo (id)
+        -- @migrate end
+        -- @migrate down
+        -- @migrate begin
+        DROP INDEX foo_idx
+        -- @migrate end
+        -- @migrate begin
+        DROP TABLE foo
+        -- @migrate end
+      SQL
+        migration = parser.call(path)
+
+        migration.apply(db, :up)
+        expect(db.tables).to include(:foo)
+        expect(db.indexes(:foo)).to have_key(:foo_idx)
+
+        migration.apply(db, :down)
+        expect(db.tables).not_to include(:foo)
+      end
+    end
+
+    it "silently skips an empty middle section" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE foo (id INTEGER PRIMARY KEY)
+        -- @migrate end
+        -- @migrate begin
+        -- @migrate end
+        -- @migrate begin
+        CREATE INDEX foo_idx ON foo (id)
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+
+        expect(db.tables).to include(:foo)
+        expect(db.indexes(:foo)).to have_key(:foo_idx)
+      end
+    end
+
+    it "raises when a direction has no begin..end section" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate down
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path) }.to raise_error(
+          ROM::SQL::SQLParseError, /Expected begin, got down/
+        )
+      end
+    end
+  end
+
+  describe "SQL comments inside section bodies" do
+    it "tokenizes plain `--` comments as :line and passes them through verbatim" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        -- This is a real SQL comment, not a directive.
+        CREATE TABLE notes (id INTEGER PRIMARY KEY);
+        -- Another comment about the next statement.
+        CREATE INDEX notes_id_idx ON notes (id);
+        -- @migrate end
+      SQL
+        tokens = File.open(path) { |f| parser.tokenize(f) }
+        line_values = tokens.select { |t| t.type == :line }.map(&:value)
+
+        expect(line_values).to eq([
+          "-- This is a real SQL comment, not a directive.",
+          "CREATE TABLE notes (id INTEGER PRIMARY KEY);",
+          "-- Another comment about the next statement.",
+          "CREATE INDEX notes_id_idx ON notes (id);"
+        ])
+
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:notes)
+      end
+    end
+
+    it "treats bare `@migrate` (no `--` prefix) as SQL content" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        SELECT '@migrate up' AS not_a_directive;
+        -- @migrate end
+      SQL
+        tokens = File.open(path) { |f| parser.tokenize(f) }
+        line_values = tokens.select { |t| t.type == :line }.map(&:value)
+
+        expect(line_values).to eq(["SELECT '@migrate up' AS not_a_directive;"])
+      end
+    end
+  end
+
+  describe "applying a direction" do
+    it "is a no-op when applying :down with no down section" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE up_only (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        migration = parser.call(path)
+        expect { migration.apply(db, :down) }.not_to raise_error
+      end
+    end
+
+    it "raises ArgumentError for an invalid direction" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        SELECT 1
+        -- @migrate end
+      SQL
+        expect { parser.call(path).apply(db, :sideways) }.to raise_error(
+          ArgumentError, /Invalid migration direction specified/
+        )
+      end
+    end
+  end
+
+  describe "execution error backtraces" do
+    it "annotates the backtrace with the failing line in a split=line section" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=line
+        CREATE TABLE good (id INTEGER PRIMARY KEY)
+        THIS IS NOT VALID SQL
+        -- @migrate end
+      SQL
+        expect { parser.call(path).apply(db, :up) }.to raise_error(Sequel::DatabaseError) do |error|
+          expect(error.backtrace.first).to eq("#{path}:4:in 'up'")
+        end
+      end
+    end
+
+    it "annotates the backtrace with the failing line in a split=semicolon section" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin split=semicolon
+        CREATE TABLE good (id INTEGER PRIMARY KEY);
+        BROKEN STATEMENT HERE;
+        -- @migrate end
+      SQL
+        expect { parser.call(path).apply(db, :up) }.to raise_error(Sequel::DatabaseError) do |error|
+          expect(error.backtrace.first).to eq("#{path}:4:in 'up'")
+        end
+      end
+    end
+
+    it "annotates the backtrace with the section's first line for a default (unsplit) body" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        BROKEN
+        STATEMENT
+        -- @migrate end
+      SQL
+        expect { parser.call(path).apply(db, :up) }.to raise_error(Sequel::DatabaseError) do |error|
+          expect(error.backtrace.first).to eq("#{path}:3:in 'up'")
+        end
+      end
+    end
+
+    it "reports the down direction in the frame when a down statement fails" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE present (id INTEGER PRIMARY KEY)
+        -- @migrate end
+        -- @migrate down
+        -- @migrate begin split=line
+        DROP TABLE present
+        DROP TABLE does_not_exist
+        -- @migrate end
+      SQL
+        migration = parser.call(path)
+        migration.apply(db, :up)
+
+        expect { migration.apply(db, :down) }.to raise_error(Sequel::DatabaseError) do |error|
+          expect(error.backtrace.first).to eq("#{path}:8:in 'down'")
+        end
+      end
+    end
+  end
+
+  describe "env=true variable substitution" do
+    around do |example|
+      saved = ENV.to_h
+      example.run
+    ensure
+      ENV.replace(saved)
+    end
+
+    it "substitutes ${NAME} from ENV in statement bodies" do
+      ENV["MIG_TABLE"] = "widgets"
+
+      with_sql(<<~SQL) do |path|
+        -- @migrate env=true
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE ${MIG_TABLE} (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db.tables).to include(:widgets)
+      end
+    end
+
+    it "leaves $$-quoted bodies and $1 params untouched" do
+      ENV["MIG_VAL"] = "resolved"
+
+      with_sql(<<~SQL) do |path|
+        -- @migrate env=true
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE notes (body TEXT)
+        -- @migrate end
+        -- @migrate begin
+        INSERT INTO notes (body) VALUES ('$1 $$ ${MIG_VAL}')
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db[:notes].get(:body)).to eq("$1 $$ resolved")
+      end
+    end
+
+    it "passes ${NAME} through verbatim when no env pragma is set" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE notes (body TEXT)
+        -- @migrate end
+        -- @migrate begin
+        INSERT INTO notes (body) VALUES ('${MIG_VAL}')
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db[:notes].get(:body)).to eq("${MIG_VAL}")
+      end
+    end
+
+    it "passes ${NAME} through verbatim when env=false" do
+      with_sql(<<~SQL) do |path|
+        -- @migrate env=false
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE notes (body TEXT)
+        -- @migrate end
+        -- @migrate begin
+        INSERT INTO notes (body) VALUES ('${MIG_VAL}')
+        -- @migrate end
+      SQL
+        parser.call(path).apply(db, :up)
+        expect(db[:notes].get(:body)).to eq("${MIG_VAL}")
+      end
+    end
+
+    it "raises SQLEnvError naming the variable and source location for a missing var" do
+      ENV.delete("MIG_MISSING")
+
+      with_sql(<<~SQL) do |path|
+        -- @migrate env=true
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE ${MIG_MISSING} (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        expect { parser.call(path).apply(db, :up) }.to raise_error(
+          ROM::SQL::SQLEnvError, /\$\{MIG_MISSING\}.*#{Regexp.escape(path)}:4/
+        )
+      end
+    end
+
+    it "aborts before any side effects when a later statement has a missing var" do
+      ENV.delete("MIG_MISSING")
+
+      with_sql(<<~SQL) do |path|
+        -- @migrate env=true
+        -- @migrate up
+        -- @migrate begin split=line
+        CREATE TABLE created_first (id INTEGER PRIMARY KEY)
+        CREATE TABLE ${MIG_MISSING} (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        expect { parser.call(path).apply(db, :up) }.to raise_error(ROM::SQL::SQLEnvError)
+        expect(db.tables).not_to include(:created_first)
+      end
+    end
+
+    it "honors transaction and env on a single pragma line" do
+      ENV["MIG_TABLE"] = "combined"
+
+      with_sql(<<~SQL) do |path|
+        -- @migrate transaction=true env=true
+        -- @migrate up
+        -- @migrate begin
+        CREATE TABLE ${MIG_TABLE} (id INTEGER PRIMARY KEY)
+        -- @migrate end
+      SQL
+        migration = parser.call(path)
+        expect(migration.use_transactions).to be(true)
+
+        migration.apply(db, :up)
+        expect(db.tables).to include(:combined)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces `ROM::SQL::Migration::SQLMigration`, which allows you to write migrations as a `.sql` file in the migration directory. This takes inspiration from my experience using [pressly/goose](https://github.com/pressly/goose).

SQL migrations have a very simple grammar:

1. Files are organized into two directions (up and down). Each direction may contain one or more `begin..end` sections; all sections for a direction execute sequentially in source order at apply time. Each section keeps its own `split=` setting, so a single direction may mix splitting strategies across sections.
2. Directives are written as SQL line comments using the `-- @migrate` sigil. The leading `--` keeps directive lines valid SQL syntax (so editors, syntax highlighters, and linters treat them as comments); the `@migrate` sigil disambiguates them from author-written `--` comments. Plain `-- ...` comments without the `@migrate` sigil are treated as part of the SQL body and pass through verbatim.
3. Optional settings may be provided in a pragma line before the up/down sections
4. Pragma and begin lines accept `key=value` settings separated by spaces or tabs
5. Each direction begins with a direction directive followed by one or more begin directives
6. The begin directive may itself carry settings (e.g. statement splitting strategy)
7. Each section concludes with an end directive
8. Down migrations are optional, but they always must follow the up migration
9. Empty sections (begin..end with no SQL body) are silently skipped

## Rationale

For very simple cases, using a Ruby DSL is fine and makes your migrations user-friendly. But a major problem with migration DSLs is that they don't look very much like the SQL they intend to replace. This means when you start to do complex things in your DB, it gets increasingly difficult to figure out how to write it. Eventually you are bound to encounter situations where it makes sense to just shove a whole SQL string into `execute`.

This extension aims to solve this problem by giving users an escape hatch into plain SQL that can sit alongside their Ruby migrations.

### Statement Splitting

Providing multiple ways to manage how your statements get split up is necessary, because different database engines have difference precise rules about it. There are three options demonstrated here: the whole body in one statement, split by line, and split by semicolon. You can also provide multiple statement sections per migration direction if you wish.

```sql
-- @migrate up

-- Extension + index can be split on `;` safely
-- @migrate begin split=semicolon
CREATE EXTENSION IF NOT EXISTS pg_trgm;
CREATE INDEX users_name_trgm_idx ON users USING gin (name gin_trgm_ops);
-- @migrate end

-- The function body is dollar-quoted and contains `;`, so it MUST stay in
-- default mode (whole body sent as one statement).
-- @migrate begin
CREATE OR REPLACE FUNCTION search_users(query text)
RETURNS SETOF users
LANGUAGE sql
STABLE
AS $$
  SELECT *
  FROM users
  WHERE name % query
  ORDER BY similarity(name, query) DESC, name ASC;
$$;
-- @migrate end

-- @migrate down
-- @migrate begin split=line
DROP FUNCTION IF EXISTS search_users(text);
DROP INDEX IF EXISTS users_name_trgm_idx;
DROP EXTENSION IF EXISTS pg_trgm;
-- @migrate end
```

### Pragma: `transaction`

Set whether or not to use a DDL transaction via a top-level pragma:

```sql
-- @migrate transaction=false
-- @migrate up
-- @migrate begin
CREATE INDEX CONCURRENTLY users_name_trgm_idx ON users USING gin (name gin_trgm_ops);
-- @migrate end

-- @migrate down
-- @migrate begin
DROP INDEX CONCURRENTLY users_name_trgrm_idx ON users;
-- @migrate end
```

### Pragma: `env`

You can opt into environment-substitution by passing the `env=true` pragma. This replaces instances of `${NAME}` with `ENV["NAME"]` in your migration statements before execution.

```sql
-- @migrate env=true
-- @migrate up
-- @migrate begin split=line
GRANT ALL ON ALL TABLES IN SCHEMA public TO "${IAM_USER}";
GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO "${IAM_USER}";
GRANT ALL ON ALL ROUTINES IN SCHEMA public TO "${IAM_USER}";
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "${IAM_USER}";
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "${IAM_USER}";
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON ROUTINES TO "${IAM_USER}";
-- @migrate end

-- @migrate down
-- @migrate begin split=line
ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON ROUTINES FROM "${IAM_USER}";
ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON SEQUENCES FROM "${IAM_USER}";
ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM "${IAM_USER}";
REVOKE ALL ON ALL ROUTINES IN SCHEMA public FROM "${IAM_USER}";
REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM "${IAM_USER}";
REVOKE ALL ON ALL TABLES IN SCHEMA public FROM "${IAM_USER}";
-- @migrate end
```

## Comments for reviewers

1. This uses recent language features like `Data`, but the gemspec is outdated. We should probably bump the requirement to 3.3
2. The unfinished transition to ROM 6 is awkward, how should we deal with that in light of an added feature? This is almost entirely additive so it would not require very much effort to merge into main. **Note that I am based on release-3.7 currently**.
3. This doesn't include anything to generate a SQL migration file, but I think this would be a `hanami-cli` followon rather than live here.
4. `rom-core` requires `dry-struct` so I felt it was acceptable to use it here, but do we want to elevate the transitive dependency to a direct one?

### AI Disclosure

The first pass at the tokenizer / compiler was crafted by hand, but I used Claude extensively here to track down edge cases. Everything I did not write has been carefully reviewed.